### PR TITLE
[Fix] 공통 color중 text color @layer utilities로 정의

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -38,6 +38,33 @@
 }
 
 @layer utilities {
+  .text-black2 {
+    color: var(--color-black2);
+  }
+  .text-black3 {
+    color: var(--color-black3);
+  }
+  .text-black4 {
+    color: var(--color-black4);
+  }
+  .text-gray1 {
+    color: var(--color-gray1);
+  }
+  .text-gray2 {
+    color: var(--color-gray2);
+  }
+  .text-gray3 {
+    color: var(--color-gray3);
+  }
+  .text-gray4 {
+    color: var(--color-gray4);
+  }
+  .text-gray5 {
+    color: var(--color-gray5);
+  }
+}
+
+@layer utilities {
   .font-32b {
     @apply text-[32px] leading-[42px] font-bold;
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -66,92 +66,146 @@
 
 @layer utilities {
   .font-32b {
-    @apply text-[32px] leading-[42px] font-bold;
+    font-size: 32px;
+    line-height: 42px;
+    font-weight: 700;
   }
   .font-32sb {
-    @apply text-[32px] leading-[42px] font-semibold;
+    font-size: 32px;
+    line-height: 42px;
+    font-weight: 600;
   }
 
   .font-24b {
-    @apply text-[24px] leading-[32px] font-bold;
+    font-size: 24px;
+    line-height: 32px;
+    font-weight: 700;
   }
   .font-24sb {
-    @apply text-[24px] leading-[32px] font-semibold;
+    font-size: 24px;
+    line-height: 32px;
+    font-weight: 600;
   }
   .font-24m {
-    @apply text-[24px] leading-[32px] font-medium;
+    font-size: 24px;
+    line-height: 32px;
+    font-weight: 500;
   }
   .font-24r {
-    @apply text-[24px] leading-[32px] font-normal;
+    font-size: 24px;
+    line-height: 32px;
+    font-weight: 400;
   }
 
   .font-20b {
-    @apply text-[20px] leading-[32px] font-bold;
+    font-size: 20px;
+    line-height: 32px;
+    font-weight: 700;
   }
   .font-20sb {
-    @apply text-[20px] leading-[32px] font-semibold;
+    font-size: 20px;
+    line-height: 32px;
+    font-weight: 600;
   }
   .font-20m {
-    @apply text-[20px] leading-[32px] font-medium;
+    font-size: 20px;
+    line-height: 32px;
+    font-weight: 500;
   }
   .font-20r {
-    @apply text-[20px] leading-[32px] font-normal;
+    font-size: 20px;
+    line-height: 32px;
+    font-weight: 400;
   }
 
   .font-18b {
-    @apply text-[18px] leading-[26px] font-bold;
+    font-size: 18px;
+    line-height: 26px;
+    font-weight: 700;
   }
   .font-18sb {
-    @apply text-[18px] leading-[26px] font-semibold;
+    font-size: 18px;
+    line-height: 26px;
+    font-weight: 600;
   }
   .font-18m {
-    @apply text-[18px] leading-[26px] font-medium;
+    font-size: 18px;
+    line-height: 26px;
+    font-weight: 500;
   }
   .font-18r {
-    @apply text-[18px] leading-[26px] font-normal;
+    font-size: 18px;
+    line-height: 26px;
+    font-weight: 400;
   }
 
   .font-16b {
-    @apply text-[16px] leading-[26px] font-bold;
+    font-size: 16px;
+    line-height: 26px;
+    font-weight: 700;
   }
   .font-16sb {
-    @apply text-[16px] leading-[26px] font-semibold;
+    font-size: 16px;
+    line-height: 26px;
+    font-weight: 600;
   }
   .font-16m {
-    @apply text-[16px] leading-[26px] font-medium;
+    font-size: 16px;
+    line-height: 26px;
+    font-weight: 500;
   }
   .font-16r {
-    @apply text-[16px] leading-[26px] font-normal;
+    font-size: 16px;
+    line-height: 26px;
+    font-weight: 400;
   }
 
   .font-14b {
-    @apply text-[14px] leading-[24px] font-bold;
+    font-size: 14px;
+    line-height: 24px;
+    font-weight: 700;
   }
   .font-14sb {
-    @apply text-[14px] leading-[24px] font-semibold;
+    font-size: 14px;
+    line-height: 24px;
+    font-weight: 600;
   }
   .font-14m {
-    @apply text-[14px] leading-[24px] font-medium;
+    font-size: 14px;
+    line-height: 24px;
+    font-weight: 500;
   }
   .font-14r {
-    @apply text-[14px] leading-[24px] font-normal;
+    font-size: 14px;
+    line-height: 24px;
+    font-weight: 400;
   }
 
   .font-13sb {
-    @apply text-[13px] leading-[22px] font-semibold;
+    font-size: 13px;
+    line-height: 22px;
+    font-weight: 600;
   }
   .font-13m {
-    @apply text-[13px] leading-[22px] font-medium;
+    font-size: 13px;
+    line-height: 22px;
+    font-weight: 500;
   }
 
   .font-12sb {
-    @apply text-[12px] leading-[20px] font-semibold;
+    font-size: 12px;
+    line-height: 20px;
+    font-weight: 600;
   }
   .font-12m {
-    @apply text-[12px] leading-[18px] font-medium;
+    font-size: 12px;
+    line-height: 18px;
+    font-weight: 500;
   }
   .font-12r {
-    @apply text-[12px] leading-[18px] font-normal;
+    font-size: 12px;
+    line-height: 18px;
+    font-weight: 400;
   }
 }
 


### PR DESCRIPTION
- 반영 브랜치
feature/GlobalStyle -> dev
---

- 변경 사항
1. 공통 color 중 text 작성에 사용되는 color들을 따로 정의했습니다.(보다 간결한 코드 작성 가능)
```
@layer utilities {
.text-black3 {
    color: var(--color-black3);
  }
}
```

변경 전 text에 color 적용 방법
`<button className="text-[var(--color-black3)]">로그인</button>`
변경 후 text에 color 적용 방법
`<button className="font-16r text-black3">로그인</button>`

2. font style 정의 방식을 변경하며 @apply를 삭제했습니다.(최신 버전에 맞지 않다고 판단)
변경 전/후 사용 방법은 같습니다.

---
- 테스트 결과
![image](https://github.com/user-attachments/assets/8715dd5b-5e0a-40e4-b015-41a0a4474e64)