### PR TITLE
[Refector, Fix] Page: 대시보드 페이지 타입 정의 및 통합

### DIFF
--- a/src/components/ColumnCard/Card.tsx
+++ b/src/components/ColumnCard/Card.tsx
@@ -1,26 +1,21 @@
 // Card.tsx
+import { CardType } from "@/types/task";
 import Image from "next/image";
 
-type ImageCardProps = {
-  title: string;
-  dueDate?: string;
-  tags: string[];
-  assignee: string;
-  imageUrl?: string;
-};
+type CardProps = CardType;
 
-export default function ImageCard({
+export default function Card({
   title = "new Task",
   dueDate,
   tags,
-  assignee = "Team4",
+  assignee,
   imageUrl = "/svgs/img.svg",
-}: ImageCardProps) {
+}: CardProps) {
   return (
     <div className="w-[314px] border border-gray-300 rounded-md p-4">
       <Image
         className="w-full h-40 object-cover rounded-md"
-        src={imageUrl}
+        src={imageUrl || "svgs/img.svg"}
         width={300}
         height={160}
         alt="Task Image"
@@ -48,7 +43,7 @@ export default function ImageCard({
           <p>{dueDate}</p>
         </div>
         <div className="w-7 h-7 flex items-center justify-center bg-[#A3C4A2] text-white font-bold rounded-full text-sm">
-          {assignee[0]}
+          {assignee.nickname[0]}
         </div>
       </div>
     </div>

--- a/src/components/ColumnCard/Column.tsx
+++ b/src/components/ColumnCard/Column.tsx
@@ -1,7 +1,7 @@
 // ColumnCard.tsx
 import TodoButton from "@/components/button/TodoButton";
 import { useState } from "react";
-import { CardType } from "../../types/task";
+import { CardType } from "@/types/task";
 import Card from "./Card";
 import Image from "next/image";
 

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,23 +1,12 @@
 // src/pages/dashboards.tsx
 import { useEffect, useState } from "react";
-import { getDashboards, getColumns, getCardsByColumn } from "../api/dashboard";
+import { getDashboards, getColumns, getCardsByColumn } from "@/api/dashboard";
 import Column from "@/components/ColumnCard/Column";
-import { CardType } from "@/types/task";
-
-// 타입 정의
-interface ColumnType {
-  id: number;
-  title: string;
-  teamId: string;
-  createdAt: string;
-  updatedAt: string;
-}
+import { CardType, ColumnType, TasksByColumn } from "@/types/task";
 
 export default function DashboardPage() {
   const [columns, setColumns] = useState<ColumnType[]>([]);
-  const [tasksByColumn, setTasksByColumn] = useState<{
-    [columnId: number]: CardType[];
-  }>({});
+  const [tasksByColumn, setTasksByColumn] = useState<TasksByColumn>({});
 
   useEffect(() => {
     const fetchDashboardsAndColumns = async () => {

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -28,5 +28,5 @@ export type ColumnType = {
 
 // 여러 칼럼별 테스크 묶음
 export type TasksByColumn = {
-  [columnIdL: number]: CardType;
+  [columnIdL: number]: CardType[];
 };


### PR DESCRIPTION
- 공통적으로 사용하는 타입을 한 파일에서 관리하도록 리팩토링했습니다.
- 중복된 타입을 제거하고, 타입 관련 에러를 수정했습니다.

### 변경사항:
- 공통 타입을 types.ts에 통합 관리하도록 수정
- 기존 컴포넌트 내 개별 선언된 타입 제거 및 통합된 타입으로 교체
- 변경으로 인한 타입 에러 수정 완료