### PR TITLE
[Fix] vercel, git actions 배포: Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,17 +48,17 @@ jobs:
 
         with:
 
-          source-directory: 'output'
+          sourceDirectory: 'output'
 
-          destination-github-username: MINJI121
+          destinationGithubUsername: MINJI121
 
-          destination-repository-name: Taskify
+          destinationRepositoryName: Taskify
 
-          user-email: ${{ secrets.EMAIL }}
+          userEmail: ${{ secrets.EMAIL }}
 
-          commit-message: ${{ github.event.commits[0].message }}
+          commitMessage: ${{ github.event.commits[0].message }}
 
-          target-branch: main
+          targetBranch: main
 
 
 


### PR DESCRIPTION
## 버그 리포트
![image](https://github.com/user-attachments/assets/e2e26ac8-d879-491a-817e-dd7db897d69d)
이미지와 같이 개인 레포지토리에 push되지 않는 error 발생

## 해결 과정
해당 문서의 아래 부분
```
source-directory: 'output'

destination-github-username: MINJI121

destination-repository-name: Taskify

user-email: ${{ secrets.EMAIL }}

commit-message: ${{ github.event.commits[0].message }}

target-branch: main
```

최신 문법인 카멜 케이스로 변경
ex) destinationGithubUsername: 'my-username'