### PR TITLE
[Fix] vercel, git actions 배포: Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 cd ../
 mkdir output
-cp -R ./[Taskify]/* ./output
-cp -R ./output ./[Taskify]/
+cp -R ./Taskify/* ./output
+cp -R ./output ./Taskify/


### PR DESCRIPTION
배포 과정에서 개인 레포지토리로 push되지 않는 에러 해결을 위해
build 파일 내 레포지토리 명의 대괄호 삭제