### PR TITLE
[Feat] landing: 로그인 상태일 때 '대시보드 이동하기' 버튼으로 전환

### DIFF
--- a/src/components/landing/Section1.tsx
+++ b/src/components/landing/Section1.tsx
@@ -1,7 +1,20 @@
+import { useRouter } from "next/router";
+import useUserStore from "@/store/useUserStore";
 import Image from "next/image";
-import Link from "next/link";
 
 export default function Section1() {
+  const user = useUserStore((state) => state.user);
+  const isLoggedIn = !!user;
+  const router = useRouter();
+
+  const handleMainClick = () => {
+    if (isLoggedIn) {
+      router.push("/mydashboard");
+    } else {
+      router.push("/login");
+    }
+  };
+
   return (
     <section className="w-full bg-[var(--color-black)] text-[var(--color-white)] px-4 pt-[94px] sm:pt-[42px] flex flex-col items-center">
       {/* 히어로 이미지 */}
@@ -34,12 +47,12 @@ export default function Section1() {
       </span>
 
       {/* CTA 버튼 */}
-      <Link
-        href="/login"
-        className="mt-[66px] w-[280px] h-[54px] flex items-center justify-center rounded-lg bg-[var(--primary)] text-[var(--color-white)] font-16m sm:mt-[70px]"
+      <button
+        onClick={handleMainClick}
+        className="mt-[66px] w-[280px] h-[54px] flex items-center justify-center rounded-lg bg-[var(--primary)] text-[var(--color-white)] font-16m sm:mt-[70px] cursor-pointer"
       >
-        로그인하기
-      </Link>
+        {isLoggedIn ? "대시보드 이동하기" : "로그인하기"}
+      </button>
     </section>
   );
 }

--- a/src/pages/mydashboard.tsx
+++ b/src/pages/mydashboard.tsx
@@ -12,7 +12,6 @@ import InvitedDashBoard from "@/components/table/invited/InvitedDashBoard";
 import NewDashboard from "@/components/modal/NewDashboard";
 import { Modal } from "@/components/modal/Modal";
 import { CustomBtn } from "@/components/button/CustomButton";
-
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 
 interface Dashboard {


### PR DESCRIPTION
## 변경 사항
landing 페이지의 Section.tsx 파일에 로그인 상태 추가
로그인 상태에서 '로그인하기' 버튼 -> '대시보드 이동하기' 버튼으로 전환

## 테스트 유무
![화면 캡처 2025-04-01 010531](https://github.com/user-attachments/assets/33009a63-85bb-4add-8c0f-8f6add4fd6f2)
![화면 캡처 2025-04-01 010542](https://github.com/user-attachments/assets/7e77f942-b939-493b-b8c5-9eb6da526207)
테스트 완료
클릭 시 페이지 이동 정상 동작