### PR TITLE
[Feat, Style] mypage: css & 반응형 수정, 정보 변경 시 toast 발생, toast 사라지면 새로고침 / Gnb: 멤버 목록 반응형 적용

### DIFF
--- a/src/components/card/ChangePassword.tsx
+++ b/src/components/card/ChangePassword.tsx
@@ -56,38 +56,42 @@ export default function ChangePassword() {
   };
 
   return (
-    <div className="sm:w-[672px] sm:h-[466px] w-[284px] h-[454px] bg-white rounded-[16px] p-[24px] flex flex-col">
+    <div
+      className="flex flex-col sm:w-[672px] sm:h-[466px] w-[284px] h-[454px]
+     bg-white rounded-[16px] p-[24px]"
+    >
       <h2 className="text-black3 text-[18px] sm:text-[24px] font-bold mb-4">
         비밀번호 변경
       </h2>
 
-      <div>
-        <div className="-mt-2 text-black3">
-          <Input
-            type="password"
-            name="password"
-            label="현재 비밀번호"
-            labelClassName="font-16r"
-            placeholder="현재 비밀번호 입력"
-            value={password}
-            onChange={setPassword}
-            pattern=".{8,}"
-            className="max-w-[620px]"
-          />
-          <Input
-            type="password"
-            name="password"
-            label="새 비밀번호"
-            labelClassName="font-16r"
-            placeholder="새 비밀번호 입력"
-            value={newPassword}
-            onChange={setNewPassword}
-            pattern=".{8,}"
-            invalidMessage="8자 이상 입력해주세요."
-            className="max-w-[620px]"
-          />
+      <div className="flex flex-col text-black3 my-3 gap-4">
+        <Input
+          type="password"
+          name="password"
+          label="현재 비밀번호"
+          labelClassName="text-[14px] sm:text-base"
+          placeholder="현재 비밀번호 입력"
+          value={password}
+          onChange={setPassword}
+          pattern=".{8,}"
+          className="max-w-[620px]"
+        />
+        <Input
+          type="password"
+          name="password"
+          label="새 비밀번호"
+          labelClassName="text-[14px] sm:text-base"
+          placeholder="새 비밀번호 입력"
+          value={newPassword}
+          onChange={setNewPassword}
+          pattern=".{8,}"
+          invalidMessage="8자 이상 입력해주세요."
+          className="max-w-[620px]"
+        />
 
-          <label className="mb-2 text-sm sm:text-base text-black mt-3">
+        {/*gap 설정용 Input 컨테이너*/}
+        <div>
+          <label className="text-[14px] sm:text-base text-black3 my-3">
             새 비밀번호 확인
           </label>
           <div className="relative w-full">
@@ -96,7 +100,8 @@ export default function ChangePassword() {
               value={checkNewpassword}
               placeholder="새 비밀번호 입력"
               onChange={(e) => setCheckNewPassword(e.target.value)}
-              className={`mt-3 sm:w-[624px] sm:h-[50px] w-[236px] h-[50px] px-[16px] pr-12 rounded-[8px] transition-colors focus:outline-none
+              className={`mt-3 sm:w-[620px] sm:h-[50px] w-[236px] h-[50px]
+                px-[16px] pr-12 rounded-[8px] transition-colors focus:outline-none
                 ${
                   checkNewpassword
                     ? checkNewpassword === newPassword
@@ -122,13 +127,27 @@ export default function ChangePassword() {
                 className=" w-5 h-5"
               />
             </button>
-
-            {checkNewpassword && checkNewpassword !== newPassword && (
-              <p className="mt-2 font-16m block text-[var(--color-red)]">
-                비밀번호가 일치하지 않습니다.
-              </p>
-            )}
           </div>
+
+          <button
+            className={`mt-6 w-full sm:w-[620x] h-[54px] 
+          rounded-[8px] text-lg font-medium text-white
+          ${
+            isDisabled
+              ? "bg-gray-300 cursor-not-allowed"
+              : "bg-[#5A3FFF] text-white cursor-pointer"
+          }`}
+            onClick={() => handleChangePassword()}
+            disabled={isDisabled || isSubmitting}
+          >
+            변경
+          </button>
+
+          {checkNewpassword && checkNewpassword !== newPassword && (
+            <p className="mt-2 font-16m block text-[var(--color-red)]">
+              비밀번호가 일치하지 않습니다.
+            </p>
+          )}
         </div>
       </div>
 
@@ -143,21 +162,11 @@ export default function ChangePassword() {
         onClose={() => setShowSuccessModal(false)}
         message="비밀번호 변경에 성공하였습니다."
       />
-
       <MypageModal
         isOpen={showErrorModal}
         onClose={() => setShowErrorModal(false)}
         message="비밀번호 변경에 실패하였습니다."
       />
-      <button
-        className={`mt-2.5 cursor-pointer w-full sm:w-[624px] h-[54px] 
-          rounded-[8px] text-lg font-medium  
-          ${isDisabled ? "bg-gray-300 cursor-not-allowed" : "bg-[#5A3FFF] text-white"}`}
-        onClick={() => handleChangePassword()}
-        disabled={isDisabled || isSubmitting}
-      >
-        변경
-      </button>
     </div>
   );
 }

--- a/src/components/card/ChangePassword.tsx
+++ b/src/components/card/ChangePassword.tsx
@@ -1,19 +1,17 @@
 import { useState } from "react";
+import { useRouter } from "next/router";
 import { changePassword } from "@/api/changepassword";
-import MypageModal from "../modal/MypageModal";
-import Input from "../input/Input";
+import Input from "@/components/input/Input";
 import Image from "next/image";
+import { toast } from "react-toastify";
 
 export default function ChangePassword() {
+  const router = useRouter();
   const [password, setPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [checkNewpassword, setCheckNewPassword] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [errorMessage, setErrorMessage] = useState("");
-  const [successMessage, setSuccessMessage] = useState("");
   const [showCheckNewPassword, setShowCheckNewPassword] = useState(false);
-  const [showSuccessModal, setShowSuccessModal] = useState(false);
-  const [showErrorModal, setShowErrorModal] = useState(false);
 
   const toggleCheckNewPasswordVisibility = () =>
     setShowCheckNewPassword(!showCheckNewPassword);
@@ -30,8 +28,6 @@ export default function ChangePassword() {
     if (isDisabled) return;
 
     setIsSubmitting(true);
-    setErrorMessage("");
-    setSuccessMessage("");
 
     const result = await changePassword({ password, newPassword });
 
@@ -41,18 +37,18 @@ export default function ChangePassword() {
           ? result.message || "현재 비밀번호가 올바르지 않습니다."
           : "비밀번호 변경 중 오류가 발생했습니다.";
 
-      setErrorMessage(msg);
-      setShowErrorModal(true);
+      toast.error(msg);
       setIsSubmitting(false);
       return;
     }
-
-    setSuccessMessage("비밀번호가 성공적으로 변경되었습니다.");
-    setShowSuccessModal(true);
+    toast.success("비밀번호가 변경되었습니다.");
     setPassword("");
     setNewPassword("");
     setCheckNewPassword("");
     setIsSubmitting(false);
+    setTimeout(() => {
+      router.reload();
+    }, 1500);
   };
 
   return (
@@ -144,29 +140,12 @@ export default function ChangePassword() {
           </button>
 
           {checkNewpassword && checkNewpassword !== newPassword && (
-            <p className="mt-2 font-16m block text-[var(--color-red)]">
+            <p className="mt-2 font-14r block text-[var(--color-red)]">
               비밀번호가 일치하지 않습니다.
             </p>
           )}
         </div>
       </div>
-
-      {errorMessage && (
-        <p className="text-red-500 text-sm mt-4">{errorMessage}</p>
-      )}
-      {successMessage && (
-        <p className="text-green-600 text-sm mt-4">{successMessage}</p>
-      )}
-      <MypageModal
-        isOpen={showSuccessModal}
-        onClose={() => setShowSuccessModal(false)}
-        message="비밀번호 변경에 성공하였습니다."
-      />
-      <MypageModal
-        isOpen={showErrorModal}
-        onClose={() => setShowErrorModal(false)}
-        message="비밀번호 변경에 실패하였습니다."
-      />
     </div>
   );
 }

--- a/src/components/card/ChangePassword.tsx
+++ b/src/components/card/ChangePassword.tsx
@@ -11,10 +11,7 @@ export default function ChangePassword() {
   const [newPassword, setNewPassword] = useState("");
   const [checkNewpassword, setCheckNewPassword] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [showCheckNewPassword, setShowCheckNewPassword] = useState(false);
 
-  const toggleCheckNewPasswordVisibility = () =>
-    setShowCheckNewPassword(!showCheckNewPassword);
   const isPasswordMismatch =
     newPassword && checkNewpassword && newPassword !== checkNewpassword;
   const isDisabled =
@@ -48,12 +45,12 @@ export default function ChangePassword() {
     setIsSubmitting(false);
     setTimeout(() => {
       router.reload();
-    }, 1500);
+    }, 1700);
   };
 
   return (
     <div
-      className="flex flex-col sm:w-[672px] sm:h-[466px] w-[284px] h-[454px]
+      className="flex flex-col w-[284px] sm:w-[548px] md:w-[672px] min:h-[454px] sm:min-h-[466px]
      bg-white rounded-[16px] p-[24px]"
     >
       <h2 className="text-black3 text-[18px] sm:text-[24px] font-bold mb-4">
@@ -70,7 +67,7 @@ export default function ChangePassword() {
           value={password}
           onChange={setPassword}
           pattern=".{8,}"
-          className="max-w-[620px]"
+          className="max-w-[624px] "
         />
         <Input
           type="password"
@@ -82,69 +79,40 @@ export default function ChangePassword() {
           onChange={setNewPassword}
           pattern=".{8,}"
           invalidMessage="8자 이상 입력해주세요."
-          className="max-w-[620px]"
+          className="max-w-[624px]"
+        />
+        <Input
+          type="password"
+          name="passwordCheck"
+          label="새 비밀번호 확인"
+          labelClassName="text-[14px] sm:text-base"
+          placeholder="새 비밀번호 입력"
+          value={checkNewpassword}
+          onChange={(value) => setCheckNewPassword(value)}
+          forceInvalid={!!checkNewpassword && checkNewpassword !== newPassword}
+          invalidMessage="비밀번호가 일치하지 않습니다."
+          className="max-w-[624px]"
         />
 
-        {/*gap 설정용 Input 컨테이너*/}
-        <div>
-          <label className="text-[14px] sm:text-base text-black3 my-3">
-            새 비밀번호 확인
-          </label>
-          <div className="relative w-full">
-            <input
-              type={showCheckNewPassword ? "text" : "password"}
-              value={checkNewpassword}
-              placeholder="새 비밀번호 입력"
-              onChange={(e) => setCheckNewPassword(e.target.value)}
-              className={`mt-3 sm:w-[620px] sm:h-[50px] w-[236px] h-[50px]
-                px-[16px] pr-12 rounded-[8px] transition-colors focus:outline-none
-                ${
-                  checkNewpassword
-                    ? checkNewpassword === newPassword
-                      ? "border border-gray-300"
-                      : "border border-[var(--color-red)]"
-                    : "border border-gray-300 focus:border-purple-500"
-                }`}
-            />
-            <button
-              type="button"
-              onClick={toggleCheckNewPasswordVisibility}
-              className="absolute right-4 top-6 flex size-6 items-center justify-center"
-            >
-              <Image
-                src={
-                  showCheckNewPassword
-                    ? "/svgs/eye-on.svg"
-                    : "/svgs/eye-off.svg"
-                }
-                alt="비밀번호 표시 토글"
-                width={20}
-                height={20}
-                className=" w-5 h-5"
-              />
-            </button>
-          </div>
-
-          <button
-            className={`mt-6 w-full h-[54px] 
+        <button
+          className={`w-full h-[54px] 
           rounded-[8px] text-lg font-medium text-white
           ${
             isDisabled
               ? "bg-gray-300 cursor-not-allowed"
               : "bg-[var(--primary)] text-white cursor-pointer"
           }`}
-            onClick={() => handleChangePassword()}
-            disabled={isDisabled || isSubmitting}
-          >
-            변경
-          </button>
+          onClick={() => handleChangePassword()}
+          disabled={isDisabled || isSubmitting}
+        >
+          변경
+        </button>
 
-          {checkNewpassword && checkNewpassword !== newPassword && (
-            <p className="mt-2 font-14r block text-[var(--color-red)]">
-              비밀번호가 일치하지 않습니다.
-            </p>
-          )}
-        </div>
+        {checkNewpassword && checkNewpassword !== newPassword && (
+          <p className="font-14r block text-[var(--color-red)]">
+            비밀번호가 일치하지 않습니다.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/components/card/ChangePassword.tsx
+++ b/src/components/card/ChangePassword.tsx
@@ -56,13 +56,13 @@ export default function ChangePassword() {
   };
 
   return (
-    <div className="sm:w-[672px] sm:h-[466px] w-[284px] h-[454px] bg-white rounded-[16px] shadow-md p-[24px] flex flex-col">
-      <h2 className="text-[18px] sm:text-[24px] font-bold mb-4">
+    <div className="sm:w-[672px] sm:h-[466px] w-[284px] h-[454px] bg-white rounded-[16px] p-[24px] flex flex-col">
+      <h2 className="text-black3 text-[18px] sm:text-[24px] font-bold mb-4">
         비밀번호 변경
       </h2>
 
       <div>
-        <div className="-mt-2">
+        <div className="-mt-2 text-black3">
           <Input
             type="password"
             name="password"

--- a/src/components/card/ChangePassword.tsx
+++ b/src/components/card/ChangePassword.tsx
@@ -130,12 +130,12 @@ export default function ChangePassword() {
           </div>
 
           <button
-            className={`mt-6 w-full sm:w-[620x] h-[54px] 
+            className={`mt-6 w-full h-[54px] 
           rounded-[8px] text-lg font-medium text-white
           ${
             isDisabled
               ? "bg-gray-300 cursor-not-allowed"
-              : "bg-[#5A3FFF] text-white cursor-pointer"
+              : "bg-[var(--primary)] text-white cursor-pointer"
           }`}
             onClick={() => handleChangePassword()}
             disabled={isDisabled || isSubmitting}

--- a/src/components/card/ChangePassword.tsx
+++ b/src/components/card/ChangePassword.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { useRouter } from "next/router";
 import { changePassword } from "@/api/changepassword";
 import Input from "@/components/input/Input";
-import Image from "next/image";
 import { toast } from "react-toastify";
 
 export default function ChangePassword() {
@@ -33,9 +32,9 @@ export default function ChangePassword() {
         result.status === 400
           ? result.message || "현재 비밀번호가 올바르지 않습니다."
           : "비밀번호 변경 중 오류가 발생했습니다.";
-
       toast.error(msg);
       setIsSubmitting(false);
+
       return;
     }
     toast.success("비밀번호가 변경되었습니다.");

--- a/src/components/card/Profile.tsx
+++ b/src/components/card/Profile.tsx
@@ -64,9 +64,11 @@ export default function ProfileCard() {
   }, []);
 
   return (
-    <div className="sm:w-[672px] sm:h-[366px] w-[284px] h-[496px] bg-white rounded-[16px] shadow-md p-[24px] flex flex-col">
+    <div className="sm:w-[672px] sm:h-[366px] w-[284px] h-[496px] bg-white rounded-[16px] p-[24px] flex flex-col">
       {/* 프로필 제목 */}
-      <h2 className="text-[18px] sm:text-[24px] font-bold mb-4">프로필</h2>
+      <h2 className="text-black3 text-[18px] sm:text-[24px] font-bold mb-4">
+        프로필
+      </h2>
       {/* 프로필 이미지 및 입력 폼 영역 */}
       <div className="flex flex-col sm:flex-row items-center sm:items-start">
         {/* 프로필 이미지 업로드 영역 */}

--- a/src/components/card/Profile.tsx
+++ b/src/components/card/Profile.tsx
@@ -55,7 +55,7 @@ export default function ProfileCard() {
       toast.success("프로필 변경이 완료되었습니다.");
       setTimeout(() => {
         router.reload();
-      }, 1500);
+      }, 1700);
     } catch (error) {
       console.error("프로필 변경 실패:", error);
       toast.error("프로필 변경에 실패하였습니다.");
@@ -67,7 +67,7 @@ export default function ProfileCard() {
   }, []);
 
   return (
-    <div className="sm:w-[672px] sm:h-[366px] w-[284px] h-[496px] bg-white rounded-[16px] p-[24px] flex flex-col">
+    <div className="flex flex-col w-[284px] sm:w-[548px] md:w-[672px] h-[496px] sm:h-[366px] bg-white rounded-[16px] p-[24px]">
       {/* 프로필 제목 */}
       <h2 className="text-black3 text-[18px] sm:text-[24px] font-bold mb-4">
         프로필
@@ -75,7 +75,7 @@ export default function ProfileCard() {
       {/* 프로필 이미지 및 입력 폼 영역 */}
       <div className="flex flex-col sm:flex-row items-center sm:items-start">
         {/* 프로필 이미지 업로드 영역 */}
-        <div className="sm:mr:0 mr-29 w-[120px] flex-shrink-0 mb-4 sm:mb-0">
+        <div className="sm:mr:0 mr-[119px] w-[120px] flex-shrink-0 mb-4 sm:mb-0">
           <div className="sm:w-[182px] sm:h-[182px] w-[100px] h-[100px] rounded-md flex items-center justify-center cursor-pointer bg-[#F5F5F5] border-transparent">
             <label className="cursor-pointer w-full h-full flex items-center justify-center">
               {image ? (
@@ -100,7 +100,7 @@ export default function ProfileCard() {
         </div>
 
         {/* 입력 폼 */}
-        <div className="flex flex-col sm:ml-[-15px] w-full sm:mt-0 mt-5 sm:w-[400px] gap-4">
+        <div className="flex flex-col sm:ml-[-15px] sm:mt-0 mt-5 w-[252px] sm:w-[276px] md:w-[400px] gap-4">
           <Input
             type="email"
             name="email"
@@ -120,7 +120,7 @@ export default function ProfileCard() {
             className="text-black4"
           />
           <button
-            className="cursor-pointer w-full sm:w-[400px] h-[54px] bg-[var(--primary)] text-white rounded-[8px] text-lg font-medium mt-3"
+            className="cursor-pointer w-[252px] sm:w-[276px] md:w-[400px] h-[54px] bg-[var(--primary)] text-white rounded-[8px] text-lg font-medium mt-3"
             onClick={handleSave}
           >
             저장

--- a/src/components/card/Profile.tsx
+++ b/src/components/card/Profile.tsx
@@ -97,13 +97,13 @@ export default function ProfileCard() {
         </div>
 
         {/* 입력 폼 */}
-        <div className="flex flex-col sm:ml-[-15px] w-full sm:mt-0 mt-5 sm:w-[400px]">
+        <div className="flex flex-col sm:ml-[-15px] w-full sm:mt-0 mt-5 sm:w-[400px] gap-4">
           <Input
             type="email"
             name="email"
             label="이메일"
-            labelClassName="font-16r"
-            value={email}
+            placeholder={email}
+            labelClassName="text-black3 text-[14px] sm:text-base"
             readOnly
           />
 
@@ -111,10 +111,11 @@ export default function ProfileCard() {
             type="text"
             name="nickname"
             label="닉네임"
-            labelClassName="font-16r"
+            labelClassName="text-black3 text-[14px] sm:text-base"
             value={nickname}
             placeholder="닉네임을 입력하세요"
             onChange={(value: string) => setNickname(value)}
+            className="text-black4"
           />
           <MypageModal
             isOpen={showSuccessModal}
@@ -128,7 +129,7 @@ export default function ProfileCard() {
           />
 
           <button
-            className="cursor-pointer w-full sm:w-[400px] h-[54px] bg-[#5A3FFF] text-white rounded-[8px] text-lg font-medium mt-3"
+            className="cursor-pointer w-full sm:w-[400px] h-[54px] bg-[var(--primary)] text-white rounded-[8px] text-lg font-medium mt-3"
             onClick={handleSave}
           >
             저장

--- a/src/components/card/Profile.tsx
+++ b/src/components/card/Profile.tsx
@@ -1,16 +1,16 @@
 import { useState, useEffect } from "react";
-import Input from "../input/Input";
+import { useRouter } from "next/router";
 import Image from "next/image";
 import { getUserInfo, updateProfile, uploadProfileImage } from "@/api/users";
-import MypageModal from "../modal/MypageModal";
+import Input from "@/components/input/Input";
+import { toast } from "react-toastify";
 
 export default function ProfileCard() {
+  const router = useRouter();
   const [image, setImage] = useState<string | null>(null);
   const [nickname, setNickname] = useState("");
   const [email, setEmail] = useState("");
   const [preview, setPreview] = useState<string | null>(null);
-  const [showSuccessModal, setShowSuccessModal] = useState(false);
-  const [showErrorModal, setShowErrorModal] = useState(false);
 
   const fetchUserData = async () => {
     try {
@@ -38,7 +38,7 @@ export default function ProfileCard() {
         setImage(response.profileImageUrl); // 서버에서 받은 URL 저장
       } catch (error) {
         console.error("이미지 업로드 실패:", error);
-        alert("이미지 업로드에 실패했습니다.");
+        toast.error("이미지 업로드에 실패하였습니다.");
       }
     }
   };
@@ -52,10 +52,13 @@ export default function ProfileCard() {
 
     try {
       await updateProfile(userProfile);
-      setShowSuccessModal(true);
+      toast.success("프로필 변경이 완료되었습니다.");
+      setTimeout(() => {
+        router.reload();
+      }, 1500);
     } catch (error) {
-      console.error("프로필 저장 실패:", error);
-      setShowErrorModal(true);
+      console.error("프로필 변경 실패:", error);
+      toast.error("프로필 변경에 실패하였습니다.");
     }
   };
 
@@ -106,7 +109,6 @@ export default function ProfileCard() {
             labelClassName="text-black3 text-[14px] sm:text-base"
             readOnly
           />
-
           <Input
             type="text"
             name="nickname"
@@ -117,17 +119,6 @@ export default function ProfileCard() {
             onChange={(value: string) => setNickname(value)}
             className="text-black4"
           />
-          <MypageModal
-            isOpen={showSuccessModal}
-            onClose={() => setShowSuccessModal(false)}
-            message="프로필 변경이 완료되었습니다."
-          />
-          <MypageModal
-            isOpen={showErrorModal}
-            onClose={() => setShowErrorModal(false)}
-            message="프로필 변경에 실패하였습니다"
-          />
-
           <button
             className="cursor-pointer w-full sm:w-[400px] h-[54px] bg-[var(--primary)] text-white rounded-[8px] text-lg font-medium mt-3"
             onClick={handleSave}

--- a/src/components/common/CustomToastContainer.tsx
+++ b/src/components/common/CustomToastContainer.tsx
@@ -1,12 +1,12 @@
 "use client";
 import "react-toastify/dist/ReactToastify.css";
-import { ToastContainer, Slide } from "react-toastify";
+import { ToastContainer, Slide, toast } from "react-toastify";
 
 const CustomToastContainer = () => {
   return (
     <ToastContainer
       position="top-center"
-      autoClose={2500}
+      autoClose={1500}
       hideProgressBar={true}
       closeButton={false}
       pauseOnHover={false}

--- a/src/components/common/CustomToastContainer.tsx
+++ b/src/components/common/CustomToastContainer.tsx
@@ -6,7 +6,7 @@ const CustomToastContainer = () => {
   return (
     <ToastContainer
       position="top-center"
-      autoClose={1500}
+      autoClose={1700}
       hideProgressBar={true}
       closeButton={false}
       pauseOnHover={false}

--- a/src/components/gnb/HeaderDashboard.tsx
+++ b/src/components/gnb/HeaderDashboard.tsx
@@ -7,7 +7,8 @@ import { MemberType, UserType } from "@/types/users";
 import { getMembers } from "@/api/members";
 import { getUserInfo } from "@/api/users";
 import { getDashboardById } from "@/api/dashboards";
-import { MemberList, UserAvatars } from "@/components/gnb/Avatars";
+import { UserProfileIcon } from "@/components/gnb/ProfileIcon";
+import MembersProfileIconList from "@/components/gnb/MembersProfileIconList";
 import UserMenu from "@/components/gnb/UserMenu";
 import MemberListMenu from "@/components/gnb/MemberListMenu";
 import InviteDashboard from "@/components/modal/InviteDashboard";
@@ -230,7 +231,7 @@ const HeaderDashboard: React.FC<HeaderDashboardProps> = ({
 
           {/*멤버 목록*/}
           {variant !== "mydashboard" && (
-            <div className="relative flex items-center justify-center w-[150px] md:w-[190px] h-[60px] md:h-[70px] whitespace-nowrap">
+            <div className="relative flex items-center justify-center w-full h-[60px] md:h-[70px] whitespace-nowrap">
               {isLoading ? (
                 <SkeletonUser />
               ) : (
@@ -239,10 +240,9 @@ const HeaderDashboard: React.FC<HeaderDashboardProps> = ({
                     onClick={() => setIsListOpen((prev) => !prev)}
                     className="flex items-center pl-[15px] md:pl-[25px] lg:pl-[30px] pr-[15px] md:pr-[25px] lg:pr-[30px] cursor-pointer"
                   >
-                    <MemberList
+                    <MembersProfileIconList
                       members={members}
                       isLoading={isLoading}
-                      variant={variant}
                     />
                   </div>
                 )
@@ -275,7 +275,7 @@ const HeaderDashboard: React.FC<HeaderDashboardProps> = ({
               ) : (
                 user && (
                   <>
-                    <UserAvatars user={user} />
+                    <UserProfileIcon user={user} />
                     <span className="hidden md:block text-black3 md:text-base md:font-medium max-w-[90px] truncate whitespace-nowrap">
                       {user.nickname}
                     </span>

--- a/src/components/gnb/HeaderDashboard.tsx
+++ b/src/components/gnb/HeaderDashboard.tsx
@@ -118,7 +118,16 @@ const HeaderDashboard: React.FC<HeaderDashboardProps> = ({
   })();
 
   return (
-    <header className="w-full h-[60px] md:h-[70px] flex items-center justify-center bg-white border-b-[1px] border-b-[var(--color-gray3)]">
+    <header
+      className={clsx(
+        "flex items-center justify-center",
+        "w-full h-[60px] md:h-[70px]",
+        "bg-white",
+        variant !== "mypage"
+          ? "border-b-[1px] border-b-[var(--color-gray3)]"
+          : ""
+      )}
+    >
       <div className="w-full flex items-center justify-between pl-[4vw]">
         {errorMessage && (
           <p className="text-sm text-[var(--color-red)] px-4 py-2">
@@ -131,7 +140,9 @@ const HeaderDashboard: React.FC<HeaderDashboardProps> = ({
           <p
             className={clsx(
               "font-20b text-black3 whitespace-nowrap",
-              variant !== "mydashboard" ? "hidden lg:block" : ""
+              variant !== "mydashboard" && variant !== "mypage"
+                ? "hidden lg:block"
+                : ""
             )}
           >
             {title}

--- a/src/components/gnb/HeaderDashboard.tsx
+++ b/src/components/gnb/HeaderDashboard.tsx
@@ -123,9 +123,7 @@ const HeaderDashboard: React.FC<HeaderDashboardProps> = ({
         "flex items-center justify-center",
         "w-full h-[60px] md:h-[70px]",
         "bg-white",
-        variant !== "mypage"
-          ? "border-b-[1px] border-b-[var(--color-gray3)]"
-          : ""
+        "border-b-[1px] border-b-[var(--color-gray3)]"
       )}
     >
       <div className="w-full flex items-center justify-between pl-[4vw]">

--- a/src/components/gnb/MemberListMenu.tsx
+++ b/src/components/gnb/MemberListMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from "react";
 import clsx from "clsx";
 import { useClosePopup } from "@/hooks/useClosePopup";
-import { UserAvatars } from "@/components/gnb/Avatars";
+import { MemberProfileIcon } from "@/components/gnb/ProfileIcon";
 import { MemberType } from "@/types/users";
 
 interface MemberListMenuProps {
@@ -23,7 +23,7 @@ const MemberListMenu: React.FC<MemberListMenuProps> = ({
     <div
       ref={ref}
       className={clsx(
-        "absolute top-full right-0 w-full z-50",
+        "absolute top-full right-0 w-[140px] sm:w-[190px] z-50",
         "bg-white border border-[var(--color-gray3)] shadow",
         "transition-all duration-200 ease-out",
         isListOpen
@@ -37,8 +37,8 @@ const MemberListMenu: React.FC<MemberListMenuProps> = ({
             key={member.id}
             className="px-4 py-2 flex items-center gap-2 hover:bg-[#f9f9f9]"
           >
-            <UserAvatars user={member} />
-            <span className="text-black3 text-sm md:text-base truncate max-w-[60px] md:max-w-[90px]">
+            <MemberProfileIcon members={member} />
+            <span className="text-black3 text-sm md:text-base truncate max-w-[60px] sm:max-w-[85px]">
               {member.nickname}
             </span>
           </li>

--- a/src/components/gnb/MembersProfileIconList.tsx
+++ b/src/components/gnb/MembersProfileIconList.tsx
@@ -1,24 +1,37 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import SkeletonUser from "@/shared/skeletonUser";
 import RandomProfile from "../table/member/RandomProfile";
 import Image from "next/image";
-import { MemberType, UserType } from "@/types/users";
+import { MemberType } from "@/types/users";
 
 /*멤버 프로필 아이콘*/
-interface MemberAvatarsProps {
+interface MemberIconProps {
   members: MemberType[];
   isLoading: boolean;
-  variant?: "mydashboard" | "dashboard" | "edit" | "mypage";
 }
 
-const MAX_VISIBLE_MEMBERS = 4;
-
-export const MemberList: React.FC<MemberAvatarsProps> = ({
+export const MembersProfileIconList: React.FC<MemberIconProps> = ({
   members,
   isLoading,
-  variant,
 }) => {
-  if (variant === "mydashboard") return null;
+  // 출력할 프로필 아이콘 최대 개수
+  const [maxVisibleMembers, setMaxVisibleMembers] = useState(4);
+
+  useEffect(() => {
+    const handleResize = () => {
+      // Tailwind 기준 sm 이하 (모바일)
+      if (window.innerWidth < 640) {
+        setMaxVisibleMembers(2);
+      } else {
+        setMaxVisibleMembers(4);
+      }
+    };
+
+    handleResize();
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
 
   return (
     <div className="flex items-center justify-center -space-x-3">
@@ -26,7 +39,7 @@ export const MemberList: React.FC<MemberAvatarsProps> = ({
         <SkeletonUser />
       ) : (
         <>
-          {members.slice(0, MAX_VISIBLE_MEMBERS).map((member) => (
+          {members.slice(0, maxVisibleMembers).map((member) => (
             <div key={member.id} className="relative rounded-full">
               {member.profileImageUrl ? (
                 <div className="relative w-[34px] h-[34px] md:w-[38px] md:h-[38px] rounded-full border-[2px] border-white overflow-hidden">
@@ -42,9 +55,11 @@ export const MemberList: React.FC<MemberAvatarsProps> = ({
               )}
             </div>
           ))}
-          {members.length > MAX_VISIBLE_MEMBERS && (
+
+          {/* 출력되지 않은 나머지 멤버 수 */}
+          {members.length > maxVisibleMembers && (
             <div className="relative flex items-center justify-center w-[34px] h-[34px] md:w-[38px] md:h-[38px] rounded-full bg-[#F4D7DA] font-16m text-[#D25B68] border-[2px] border-white overflow-hidden">
-              +{members.length - MAX_VISIBLE_MEMBERS}
+              +{members.length - maxVisibleMembers}
             </div>
           )}
         </>
@@ -53,22 +68,4 @@ export const MemberList: React.FC<MemberAvatarsProps> = ({
   );
 };
 
-/*유저 프로필 아이콘*/
-interface UserAvatarProps {
-  user: UserType;
-}
-
-export const UserAvatars: React.FC<UserAvatarProps> = ({ user }) => (
-  <div className="relative w-[34px] h-[34px] md:w-[38px] md:h-[38px] rounded-full overflow-hidden">
-    {user.profileImageUrl ? (
-      <Image
-        src={user.profileImageUrl}
-        alt="유저 프로필 아이콘"
-        fill
-        className="object-cover"
-      />
-    ) : (
-      <RandomProfile name={user.nickname} />
-    )}
-  </div>
-);
+export default MembersProfileIconList;

--- a/src/components/gnb/ProfileIcon.tsx
+++ b/src/components/gnb/ProfileIcon.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import RandomProfile from "../table/member/RandomProfile";
+import Image from "next/image";
+import { MemberType, UserType } from "@/types/users";
+
+/*멤버 프로필 아이콘*/
+interface MemberIconProps {
+  members: MemberType;
+  variant?: "mydashboard" | "dashboard" | "edit" | "mypage";
+}
+
+export const MemberProfileIcon: React.FC<MemberIconProps> = ({ members }) => (
+  <div className="relative w-[34px] h-[34px] md:w-[38px] md:h-[38px] rounded-full overflow-hidden">
+    {members.profileImageUrl ? (
+      <Image
+        src={members.profileImageUrl}
+        alt="멤버 프로필 아이콘"
+        fill
+        className="object-cover"
+      />
+    ) : (
+      <RandomProfile name={members.nickname} />
+    )}
+  </div>
+);
+
+/*유저 프로필 아이콘*/
+interface UserIconProps {
+  user: UserType;
+}
+
+export const UserProfileIcon: React.FC<UserIconProps> = ({ user }) => (
+  <div className="relative w-[34px] h-[34px] md:w-[38px] md:h-[38px] rounded-full overflow-hidden">
+    {user.profileImageUrl ? (
+      <Image
+        src={user.profileImageUrl}
+        alt="유저 프로필 아이콘"
+        fill
+        className="object-cover"
+      />
+    ) : (
+      <RandomProfile name={user.nickname} />
+    )}
+  </div>
+);

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -12,6 +12,7 @@ interface GeneralInputProps {
   value?: string;
   readOnly?: boolean; //입력방지 추가
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  forceInvalid?: boolean;
 }
 
 interface SignInputProps extends Omit<GeneralInputProps, "type"> {
@@ -21,6 +22,7 @@ interface SignInputProps extends Omit<GeneralInputProps, "type"> {
   invalidMessage?: string;
   labelClassName?: string;
   wrapperClassName?: string;
+  forceInvalid?: boolean;
 }
 
 type InputProps = GeneralInputProps | SignInputProps;

--- a/src/components/table/member/MemberList.tsx
+++ b/src/components/table/member/MemberList.tsx
@@ -32,7 +32,7 @@ const MemberList: React.FC<HeaderBebridgeProps> = ({ dashboardId }) => {
       await axiosInstance.delete(apiRoutes.memberDetail(id));
       window.location.reload();
     } catch (error) {
-      toast.error("구성원원 삭제에 실패하였습니다 .");
+      toast.error("구성원 삭제에 실패하였습니다.");
       console.error("구성원 삭제 실패:", error);
     }
   };

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from "react";
+import { useRouter } from "next/router";
 import { useAuthGuard } from "@/hooks/useAuthGuard";
+import Image from "next/image";
 import HeaderMyPage from "@/components/gnb/HeaderDashboard";
 import SideMenu from "@/components/sideMenu/SideMenu";
 import ProfileCard from "@/components/card/Profile";
@@ -10,6 +12,7 @@ import LoadingSpinner from "@/components/common/LoadingSpinner";
 
 export default function MyPage() {
   const { user, isInitialized } = useAuthGuard();
+  const router = useRouter();
   const [dashboards, setDashboards] = useState<Dashboard[]>([]);
 
   const fetchDashboards = async () => {
@@ -32,13 +35,33 @@ export default function MyPage() {
   }
 
   return (
-    <div className="flex">
+    <div className="flex h-screen overflow-hidden">
       <SideMenu teamId={TEAM_ID} dashboardList={dashboards} />
-      <div className="flex flex-col w-full bg-[var(--color-gray5)]">
+      <div className="flex flex-col flex-1 bg-[var(--color-gray5)]">
         <HeaderMyPage variant="mypage" />
-        <div className="flex flex-col justify-start w-full mt-10">
-          <ProfileCard />
-          <ChangePassword />
+        <div className="flex flex-col justify-start w-full pl-10 mt-10">
+          {/*돌아가기 버튼*/}
+          <div className="flex gap-[8px]">
+            <Image
+              src="/svgs/arrow-backward-black.svg"
+              alt="돌아가기"
+              width={20}
+              height={20}
+            />
+            <button
+              onClick={() => router.back()}
+              className="flex justify-start cursor-pointer"
+            >
+              돌아가기
+            </button>
+          </div>
+
+          <div className="mt-8">
+            <ProfileCard />
+          </div>
+          <div className="mt-8">
+            <ChangePassword />
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -39,7 +39,7 @@ export default function MyPage() {
       <SideMenu teamId={TEAM_ID} dashboardList={dashboards} />
       <div className="flex flex-col flex-1 bg-[var(--color-gray5)]">
         <HeaderMyPage variant="mypage" />
-        <div className="flex flex-col justify-start w-full pl-10 mt-10">
+        <div className="flex flex-col justify-start overflow-auto w-full pl-10 mt-6">
           {/*돌아가기 버튼*/}
           <div className="flex gap-[8px]">
             <Image
@@ -59,7 +59,7 @@ export default function MyPage() {
           <div className="mt-8">
             <ProfileCard />
           </div>
-          <div className="mt-8">
+          <div className="mt-8 mb-20">
             <ChangePassword />
           </div>
         </div>

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from "react";
+import { useAuthGuard } from "@/hooks/useAuthGuard";
 import HeaderMyPage from "@/components/gnb/HeaderDashboard";
 import SideMenu from "@/components/sideMenu/SideMenu";
 import ProfileCard from "@/components/card/Profile";
 import ChangePassword from "@/components/card/ChangePassword";
 import { Dashboard, getDashboards } from "@/api/dashboards";
-import { useAuthGuard } from "@/hooks/useAuthGuard";
 import { TEAM_ID } from "@/constants/team";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
 
 export default function MyPage() {
   const { user, isInitialized } = useAuthGuard();
@@ -26,10 +27,14 @@ export default function MyPage() {
     }
   }, [isInitialized, user]);
 
+  if (!isInitialized || !user) {
+    return <LoadingSpinner />;
+  }
+
   return (
     <div className="flex">
       <SideMenu teamId={TEAM_ID} dashboardList={dashboards} />
-      <div className="flex flex-col w-full">
+      <div className="flex flex-col w-full bg-[var(--color-gray5)]">
         <HeaderMyPage variant="mypage" />
         <div className="flex flex-col justify-start w-full mt-10">
           <ProfileCard />

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -39,28 +39,32 @@ export default function MyPage() {
       <SideMenu teamId={TEAM_ID} dashboardList={dashboards} />
       <div className="flex flex-col flex-1 bg-[var(--color-gray5)]">
         <HeaderMyPage variant="mypage" />
-        <div className="flex flex-col justify-start overflow-auto w-full pl-10 mt-6">
+        <div className="flex flex-col justify-start overflow-auto w-full px-6 mt-6">
           {/*돌아가기 버튼*/}
           <div className="flex gap-[8px]">
             <Image
+              onClick={() => router.back()}
               src="/svgs/arrow-backward-black.svg"
               alt="돌아가기"
               width={20}
               height={20}
+              className="cursor-pointer"
             />
             <button
               onClick={() => router.back()}
-              className="flex justify-start cursor-pointer"
+              className="flex justify-start text-black3 cursor-pointer"
             >
               돌아가기
             </button>
           </div>
 
-          <div className="mt-8">
-            <ProfileCard />
-          </div>
-          <div className="mt-8 mb-20">
-            <ChangePassword />
+          <div className="flex flex-col items-center lg:items-start gap-6">
+            <div className="mt-8">
+              <ProfileCard />
+            </div>
+            <div className="mb-20">
+              <ChangePassword />
+            </div>
           </div>
         </div>
       </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -49,6 +49,10 @@
   display: none !important;
 }
 
+.Toastify__toast-icon {
+  color: #5534da !important;
+}
+
 @layer base {
   :root {
     --primary: #5534da;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,29 +19,29 @@
 
 .Toastify__toast {
   width: 250px !important;
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 14px 18px;
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 400;
 }
 
 .Toastify__toast--success {
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 14px 18px;
   background-color: #f3f0ff !important;
   color: #5534da !important;
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 400;
   box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
 }
 
 .Toastify__toast--error {
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 14px 18px;
-  background-color: #f3f0ff;
-  color: #d549b6;
+  background-color: white !important;
+  color: #d549b6 !important;
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 400;
   box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
 }
 
@@ -49,8 +49,14 @@
   display: none !important;
 }
 
-.Toastify__toast-icon {
-  color: #5534da !important;
+/* success 토스트: 프라이머리 컬러 */
+.Toastify__toast-icon svg {
+  fill: #5534da !important;
+}
+
+/* error 토스트: 핑크 */
+.Toastify__toast--error .Toastify__toast-icon svg {
+  fill: #d549b6 !important;
 }
 
 @layer base {


### PR DESCRIPTION
## 변경 사항
1. mypage: 전반적인 css & 반응형 디자인 수정
2. mypage: 돌아가기 버튼 추가
3. mypage_Profile, ChangePassword: 폰트, 컬러, 여백 등 규격에 맞게 수정
4. mypage_Profile, ChangePassword: 변경 성공 시 토스트 발생, 토스트 사라지면 자동 새로고침
5. ChangePassword_새 비밀번호 input: Input 컴포넌트를 커스텀해 사용하는 것으로 리팩토링(규격이 달라서 통일함)
6. Gnb_MembersProfileIconList: 모바일 이하에서는 최대 3개 출력으로 반응형 변경

## 테스트 유무
![화면 캡처 2025-04-02 035420_mypage1](https://github.com/user-attachments/assets/57e821b3-3857-4372-8a87-a16f0802780c)
![화면 캡처 2025-04-02 035420_mypage2](https://github.com/user-attachments/assets/611414d4-d0b5-4edf-be7c-f598729ad830)
테스트 완료
닉네임 변경, 비밀번호 변경 등 기능 정상 동작