### PR TITLE
[Fix, Refactor] Profile: 이미지 업로드 제한 용량 초과 시 에러 처리 / Input: Props 미전달 콘솔 에러 처리

### DIFF
--- a/src/components/card/ChangePassword.tsx
+++ b/src/components/card/ChangePassword.tsx
@@ -12,7 +12,7 @@ export default function ChangePassword() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const isPasswordMismatch =
-    newPassword && checkNewpassword && newPassword !== checkNewpassword;
+    !!checkNewpassword && checkNewpassword !== newPassword;
   const isDisabled =
     !password ||
     !newPassword ||
@@ -88,10 +88,15 @@ export default function ChangePassword() {
           placeholder="새 비밀번호 입력"
           value={checkNewpassword}
           onChange={(value) => setCheckNewPassword(value)}
-          forceInvalid={!!checkNewpassword && checkNewpassword !== newPassword}
+          forceInvalid={isPasswordMismatch}
           invalidMessage="비밀번호가 일치하지 않습니다."
           className="max-w-[624px]"
         />
+        {checkNewpassword && checkNewpassword !== newPassword && (
+          <p className="font-14r block text-[var(--color-red)]">
+            비밀번호가 일치하지 않습니다.
+          </p>
+        )}
 
         <button
           className={`w-full h-[54px] 
@@ -106,12 +111,6 @@ export default function ChangePassword() {
         >
           변경
         </button>
-
-        {checkNewpassword && checkNewpassword !== newPassword && (
-          <p className="font-14r block text-[var(--color-red)]">
-            비밀번호가 일치하지 않습니다.
-          </p>
-        )}
       </div>
     </div>
   );

--- a/src/components/card/Profile.tsx
+++ b/src/components/card/Profile.tsx
@@ -26,8 +26,16 @@ export default function ProfileCard() {
   const handleImageUpload = async (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
+    const MAX_IMAGE_SIZE = 3.5 * 1024 * 1024;
+
     if (event.target.files && event.target.files[0]) {
       const file = event.target.files[0];
+
+      if (file.size > MAX_IMAGE_SIZE) {
+        toast.error("3.5MB 이하의 이미지만 업로드할 수 있습니다.");
+        return;
+      }
+
       setPreview(URL.createObjectURL(file)); // 미리보기
 
       try {
@@ -42,6 +50,7 @@ export default function ProfileCard() {
       }
     }
   };
+
   const handleSave = async () => {
     if (!nickname || !image) return;
 

--- a/src/components/common/CustomToastContainer.tsx
+++ b/src/components/common/CustomToastContainer.tsx
@@ -6,10 +6,11 @@ const CustomToastContainer = () => {
   return (
     <ToastContainer
       position="top-center"
-      autoClose={1500}
+      autoClose={3000}
+      newestOnTop
       closeButton={false}
       pauseOnHover={false}
-      newestOnTop
+      hideProgressBar={true}
       transition={Slide}
     />
   );

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -39,6 +39,7 @@ export default function Input(props: InputProps) {
     className,
     labelClassName,
     wrapperClassName,
+    forceInvalid,
     ...rest
   } = props as SignInputProps;
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -5,7 +5,6 @@ import { getUserInfo } from "@/api/users";
 import { postAuthData } from "@/api/auth";
 import Link from "next/link";
 import Input from "@/components/input/Input";
-import { apiRoutes } from "@/api/apiRoutes";
 import { toast } from "react-toastify";
 
 export default function LoginPage() {

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -28,8 +28,6 @@ export default function LoginPage() {
     const { email, password } = values;
 
     try {
-      // 배포 테스트
-      console.log("로그인 요청 URL:", apiRoutes.login());
       const response = await postAuthData({ email, password });
       const token = response.accessToken;
       localStorage.setItem("accessToken", token);


### PR DESCRIPTION
## 변경 사항

1. 프로필 컴포넌트에서 제한 용량 초과 이미지 업로드 시 에러 발생,
3.5MB의 제한 용량 초과 시 에러 토스트 메시지 발생하도록 처리.
업로드 실패 시 미리보기 이미지 변경되지 않도록 수정.

2. Input 컴포넌트에서 forceInvarid(유효성 검사) props 전달되지 않고 있어 콘솔 에러 발생, props에 추가해 처리.

3. ChangePassword 새 비밀번호 확인 연산자 코드 단축 리팩토링

4. 토스트 표시 시간 3000밀리초로 변경

## 테스트 유무
테스트 완료