### PR TITLE
[Style] edit: 태블릿, 모바일에서 구성원, 초대 내역 텍스트 이탈 문제 수정

### DIFF
--- a/src/components/table/InviteRecords.tsx
+++ b/src/components/table/InviteRecords.tsx
@@ -100,7 +100,7 @@ const InviteRecords = ({ dashboardId }: { dashboardId: string }) => {
   };
 
   return (
-    <div className="lg:w-[620px] lg:h-[404px] w-[284px] h-[337px] sm:w-[544px] sm:h-[404px] relative p-6 rounded-lg bg-white">
+    <div className="lg:w-[620px] w-[284px] sm:w-[544px] min:h-[337px] sm:h-[430px] relative p-6 rounded-lg bg-white">
       <div className="flex justify-between items-start sm:items-center">
         {/* 제목 */}
         <p className="md:text-[24px] text-[20px] text-xl font-bold">

--- a/src/components/table/TablePagination.tsx
+++ b/src/components/table/TablePagination.tsx
@@ -22,8 +22,8 @@ const Pagination: React.FC<PaginationProps> = ({
         <button
           onClick={onPrev}
           disabled={currentPage === 1}
-          className={`w-9 sm:w-10 h-9 sm:h-10 flex justify-center items-center border-r border-gray-300 hover:bg-gray-100 
-            ${currentPage === 1 ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+          className={`w-9 sm:w-10 h-9 sm:h-10 flex justify-center items-center border-r border-gray-300
+            ${currentPage === 1 ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:bg-gray-100"}`}
         >
           <img
             src="/svgs/arrow_backward_white.svg"

--- a/src/components/table/member/MemberList.tsx
+++ b/src/components/table/member/MemberList.tsx
@@ -62,7 +62,7 @@ const MemberList: React.FC<HeaderBebridgeProps> = ({ dashboardId }) => {
   }, [dashboardId]);
 
   return (
-    <div className="lg:w-[620px] lg:h-[404px] w-[284px] h-[337px] sm:w-[544px] sm:h-[404px] relative p-6 rounded-lg bg-white">
+    <div className="lg:w-[620px] lg:h-[404px] w-[284px] min:h-[337px] sm:w-[544px] sm:h-[404px] relative p-6 rounded-lg bg-white">
       <div className="flex justify-between items-center">
         <p className="text-xl sm:text-2xl font-bold">구성원</p>
         <Pagination

--- a/src/pages/dashboard/[dashboardId]/edit.tsx
+++ b/src/pages/dashboard/[dashboardId]/edit.tsx
@@ -100,7 +100,7 @@ export default function EditDashboard() {
             <InviteRecords dashboardId={dashboardIdString || ""} />{" "}
             {/* undefined일 경우 빈 문자열로 전달*/}
           </div>
-          <div className="flex mt-15 sm:mt-0 ml-6">
+          <div className="flex mt-6 sm:mt-0">
             <button
               onClick={openModal}
               className="text-base sm:text-lg cursor-pointer w-[284px] h-[52px] sm:w-[320px] sm:h-[62px] text-black3 rounded-[8px] border-[1px] border-[var(--color-gray3)] hover:scale-105 transition-transform duration-200"


### PR DESCRIPTION
## 변경 사항
1. edit_InviteRecords, MemberList: min-h 설정으로 리스트 증가 시 컨테이너 높이 유동 조절되도록 변경
2. edit_Pagination: 버튼 비활성화 시 토글 효과 제거되도록 변경

## 테스트 유무
![초대내역길어지면텍스트이탈](https://github.com/user-attachments/assets/3769d423-2911-4f89-92b9-32ae5b4c2a83)
![초대내역길어지면텍스트이탈_수정(min-h최소높이설정)](https://github.com/user-attachments/assets/8ba11b24-87b0-4950-9aec-73868d845212)
수정 전/후 테스트 완료