### PR TITLE
[Refactor, Style] DropdownMenu: 재 클릭 시 닫힘 / Column: 여백, 반응형 조정 / Card: 긴 제목 생략 모바일에도 적용

### DIFF
--- a/src/components/button/CardButton.tsx
+++ b/src/components/button/CardButton.tsx
@@ -73,14 +73,14 @@ const CardButton: React.FC<CardButtonProps> = ({
       )}
     >
       {/* 왼쪽: 색상 도트 + 제목 + 왕관 */}
-      <div className="flex items-center font-semibold gap-[10px] overflow-hidden">
+      <div className="flex items-center overflow-hidden font-semibold gap-[10px]">
         {/* 색상 원 */}
         <svg width="8" height="8" viewBox="0 0 8 8" fill={color}>
           <circle cx="4" cy="4" r="4" />
         </svg>
 
         {/* 제목 */}
-        <span className="text-black3 text-[14px] sm:text-[16px] truncate max-w-[90px] sm:max-w-[100px] md:max-w-[120px] lg:max-w-[160px]">
+        <span className="text-black3 text-[14px] sm:text-[16px] truncate max-w-[120px]">
           {title}
         </span>
 

--- a/src/components/button/ColumnsButton.tsx
+++ b/src/components/button/ColumnsButton.tsx
@@ -8,7 +8,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 const ColumnsButton: React.FC<ButtonProps> = ({
   fullWidth,
   className,
-  children = "새로운 컬럼 추가하기",
+  children = "새로운 칼럼 추가하기",
   ...props
 }) => {
   return (

--- a/src/components/button/ColumnsButton.tsx
+++ b/src/components/button/ColumnsButton.tsx
@@ -17,10 +17,10 @@ const ColumnsButton: React.FC<ButtonProps> = ({
         "flex justify-center items-center gap-[10px] bg-white transition-all",
         "rounded-lg px-4 py-3 font-semibold",
         "border border-gray-200 hover:border-purple-500",
-        fullWidth ? "w-full" : "w-[284px] md:w-[544px] lg:w-[354px]",
+        fullWidth ? "w-full" : "w-[260px] sm:w-[560px] lg:w-[354px]",
         "h-[70px] md:h-[70px] lg:h-[70px]",
-        "mt-[10px] md:mt-[16px] lg:mt-[20px]",
-        "text-lg md:text-2lg lg:text-2lg",
+        "mt-[6px] md:mt-[8px]",
+        "text-black3 text-lg md:text-2lg",
         "cursor-pointer",
         className
       )}

--- a/src/components/button/TodoButton.tsx
+++ b/src/components/button/TodoButton.tsx
@@ -17,7 +17,7 @@ const TodoButton: React.FC<ButtonProps> = ({
         "flex justify-center items-center gap-[10px] bg-white transition-all",
         "rounded-lg px-4 py-3 font-semibold",
         "border border-gray-200 hover:border-purple-500",
-        fullWidth ? "w-full" : "w-[284px] md:w-[544px] lg:w-[314px]",
+        fullWidth ? "w-full" : "w-[225px] sm:w-[525px] lg:w-[314px]",
         "h-[32px] md:h-[40px] lg:h-[40px]",
         "mt-[10px] md:mt-[16px] lg:mt-[20px]",
         "text-lg md:text-2lg lg:text-2lg",

--- a/src/components/columnCard/Card.tsx
+++ b/src/components/columnCard/Card.tsx
@@ -50,10 +50,9 @@ export default function Card({
         {/* 제목 */}
         <h3
           className={`
-            text-lg font-semibold mt-2
-            md:text-sm md:mt-0
-            lg:text-lg lg:mt-2
-            truncate
+            text-black3 text-[14px] font-medium mt-2
+            md:text-[16px] md:mt-0 lg:mt-2
+            truncate max-w-[180px] sm:max-w-none
           `}
         >
           {title}

--- a/src/components/columnCard/CardList.tsx
+++ b/src/components/columnCard/CardList.tsx
@@ -68,7 +68,10 @@ export default function CardList({
 
   /* 무한 스크롤 */
   useEffect(() => {
-    if (!observerRef.current) return;
+    const scrollContainer = document.getElementById(
+      `scroll-column-${columnId}`
+    );
+    if (!scrollContainer || !hasMore) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -76,10 +79,10 @@ export default function CardList({
           fetchMoreCards();
         }
       },
-      { threshold: 0.5 }
+      { root: scrollContainer, threshold: 0.5 }
     );
 
-    observer.observe(observerRef.current);
+    if (observerRef.current) observer.observe(observerRef.current);
 
     return () => observer.disconnect();
   }, [fetchMoreCards, hasMore]);
@@ -94,7 +97,7 @@ export default function CardList({
           onClick={() => onCardClick(task)}
         />
       ))}
-      {hasMore && <div ref={observerRef} className="h-20 " />}
+      {hasMore && <div ref={observerRef} className="h-15" />}
     </div>
   );
 }

--- a/src/components/columnCard/CardList.tsx
+++ b/src/components/columnCard/CardList.tsx
@@ -85,7 +85,7 @@ export default function CardList({
   }, [fetchMoreCards, hasMore]);
 
   return (
-    <div className="grid gap-3 w-full grid-cols-1">
+    <div className="grid gap-3 w-full grid-cols-1 overflow-x-hidden">
       {cards.map((task) => (
         <Card
           key={task.id}

--- a/src/components/columnCard/CardList.tsx
+++ b/src/components/columnCard/CardList.tsx
@@ -68,10 +68,7 @@ export default function CardList({
 
   /* 무한 스크롤 */
   useEffect(() => {
-    const scrollContainer = document.getElementById(
-      `scroll-column-${columnId}`
-    );
-    if (!scrollContainer || !hasMore) return;
+    if (!observerRef.current) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -79,16 +76,16 @@ export default function CardList({
           fetchMoreCards();
         }
       },
-      { root: scrollContainer, threshold: 0.5 }
+      { threshold: 0.5 }
     );
 
-    if (observerRef.current) observer.observe(observerRef.current);
+    observer.observe(observerRef.current);
 
     return () => observer.disconnect();
   }, [fetchMoreCards, hasMore]);
 
   return (
-    <div className="grid gap-3 w-full grid-cols-1 overflow-x-hidden">
+    <div className="grid gap-3 w-full grid-cols-1">
       {cards.map((task) => (
         <Card
           key={task.id}
@@ -97,7 +94,7 @@ export default function CardList({
           onClick={() => onCardClick(task)}
         />
       ))}
-      {hasMore && <div ref={observerRef} className="h-15" />}
+      {hasMore && <div ref={observerRef} className="h-20" />}
     </div>
   );
 }

--- a/src/components/columnCard/Column.tsx
+++ b/src/components/columnCard/Column.tsx
@@ -100,8 +100,8 @@ export default function Column({
   return (
     <div
       className={`
-      flex flex-col border-r border-[var(--color-gray4)] bg-[#F5F2FC] rounded-md p-4
-      h-auto sm:m-h-screen
+      flex flex-col border-r border-[var(--color-gray4)] bg-[#F5F2FC] rounded-[12px] p-4
+      h-auto sm:m-h-screen overflow-y-auto overflow-x-hidden mr-4 mb-4
       max-h-[401px] sm:max-h-none w-full lg:w-[360px]
     `}
     >

--- a/src/components/columnCard/Column.tsx
+++ b/src/components/columnCard/Column.tsx
@@ -99,42 +99,46 @@ export default function Column({
 
   return (
     <div
-      id={`scroll-column-${columnId}`}
       className={`
-      flex flex-col overflow-auto shrink-0 p-4 mr-4 mb-4
+      flex flex-col shrink-0 overflow-hidden p-4 mr-4 mb-4
       border-r border-[var(--color-gray4)] bg-[#F5F2FC] rounded-[12px]
       max-h-[401px] lg:max-h-none w-full lg:w-[360px]
       `}
     >
       {/* 칼럼 헤더 */}
-      <div className="flex items-center justify-between shrink-0">
-        <div className="flex items-center gap-2">
-          <h2 className="text-lg font-bold">
-            <span className="text-[var(--primary)]">•</span> {columnTitle}
-          </h2>
-          <span className="w-5 h-5 text-sm bg-gray-200 text-gray-700 rounded-[4px] flex items-center justify-center ">
-            {tasks.length}
-          </span>
+      <div className="shrink-0">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-bold">
+              <span className="text-[var(--primary)]">•</span> {columnTitle}
+            </h2>
+            <span className="w-5 h-5 text-sm bg-gray-200 text-gray-700 rounded-[4px] flex items-center justify-center ">
+              {tasks.length}
+            </span>
+          </div>
+          <Image
+            src="/svgs/settings.svg"
+            alt="setting icon"
+            width={24}
+            height={24}
+            priority
+            className="cursor-pointer"
+            onClick={() => setIsColumnModalOpen(true)}
+          />
         </div>
-        <Image
-          src="/svgs/settings.svg"
-          alt="setting icon"
-          width={24}
-          height={24}
-          priority
-          className="cursor-pointer"
-          onClick={() => setIsColumnModalOpen(true)}
-        />
       </div>
 
       {/* 카드 영역 */}
-      <div className="flex-1 flex flex-col items-center pb-4 gap-3">
+      <div className="flex-1 flex flex-col overflow-hidden items-center pb-4 gap-2">
         <div onClick={() => setIsTodoModalOpen(true)} className="mb-2">
           <TodoButton />
         </div>
 
         {/* 무한스크롤 카드 리스트로 대체 */}
-        <div className="w-full">
+        <div
+          className="flex-1 w-full overflow-y-auto overflow-x-hidden"
+          style={{ scrollbarGutter: "stable" }}
+        >
           <CardList
             columnId={columnId}
             teamId={TEAM_ID}

--- a/src/components/columnCard/Column.tsx
+++ b/src/components/columnCard/Column.tsx
@@ -101,13 +101,13 @@ export default function Column({
     <div
       id={`scroll-column-${columnId}`}
       className={`
-      flex flex-col border-r border-[var(--color-gray4)] bg-[#F5F2FC] rounded-[12px]
-      overflow-auto p-4 mr-4 mb-4
-      max-h-[401px] md:max-h-none w-full lg:w-[360px] shrink-0
+      flex flex-col overflow-auto shrink-0 p-4 mr-4 mb-4
+      border-r border-[var(--color-gray4)] bg-[#F5F2FC] rounded-[12px]
+      max-h-[401px] lg:max-h-none w-full lg:w-[360px]
       `}
     >
       {/* 칼럼 헤더 */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between shrink-0">
         <div className="flex items-center gap-2">
           <h2 className="text-lg font-bold">
             <span className="text-[var(--primary)]">•</span> {columnTitle}
@@ -128,7 +128,7 @@ export default function Column({
       </div>
 
       {/* 카드 영역 */}
-      <div className="flex-1 pb-4 flex flex-col items-center gap-3">
+      <div className="flex-1 flex flex-col items-center pb-4 gap-3">
         <div onClick={() => setIsTodoModalOpen(true)} className="mb-2">
           <TodoButton />
         </div>

--- a/src/components/columnCard/Column.tsx
+++ b/src/components/columnCard/Column.tsx
@@ -100,8 +100,8 @@ export default function Column({
   return (
     <div
       className={`
-      flex flex-col shrink-0 overflow-hidden p-4 mr-4 mb-4
-      border-r border-[var(--color-gray4)] bg-[#F5F2FC] rounded-[12px]
+      flex flex-col shrink-0 overflow-hidden p-4 mr-4 lg:my-0 mb-4
+      border border-[var(--color-gray4)] bg-[#F5F2FC] rounded-[12px]
       max-h-[401px] lg:max-h-none w-full lg:w-[360px]
       `}
     >
@@ -109,8 +109,9 @@ export default function Column({
       <div className="shrink-0">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <h2 className="text-lg font-bold">
-              <span className="text-[var(--primary)]">•</span> {columnTitle}
+            <Image src="/svgs/ellipse.svg" alt="circle" width={8} height={8} />
+            <h2 className="text-black3 text-[16px] md:text-[18px] font-bold">
+              {columnTitle}
             </h2>
             <span className="w-5 h-5 text-sm bg-gray-200 text-gray-700 rounded-[4px] flex items-center justify-center ">
               {tasks.length}

--- a/src/components/columnCard/Column.tsx
+++ b/src/components/columnCard/Column.tsx
@@ -99,11 +99,12 @@ export default function Column({
 
   return (
     <div
+      id={`scroll-column-${columnId}`}
       className={`
-      flex flex-col border-r border-[var(--color-gray4)] bg-[#F5F2FC] rounded-[12px] p-4
-      h-auto sm:m-h-screen overflow-y-auto overflow-x-hidden mr-4 mb-4
-      max-h-[401px] sm:max-h-none w-full lg:w-[360px]
-    `}
+      flex flex-col border-r border-[var(--color-gray4)] bg-[#F5F2FC] rounded-[12px]
+      overflow-auto p-4 mr-4 mb-4
+      max-h-[401px] md:max-h-none w-full lg:w-[360px] shrink-0
+      `}
     >
       {/* 칼럼 헤더 */}
       <div className="flex items-center justify-between">
@@ -133,7 +134,7 @@ export default function Column({
         </div>
 
         {/* 무한스크롤 카드 리스트로 대체 */}
-        <div className="w-full max-h-[800px] overflow-y-auto">
+        <div className="w-full">
           <CardList
             columnId={columnId}
             teamId={TEAM_ID}

--- a/src/components/gnb/HeaderDashboard.tsx
+++ b/src/components/gnb/HeaderDashboard.tsx
@@ -238,6 +238,7 @@ const HeaderDashboard: React.FC<HeaderDashboardProps> = ({
               ) : (
                 members && (
                   <div
+                    onMouseDown={(e) => e.stopPropagation()}
                     onClick={() => setIsListOpen((prev) => !prev)}
                     className="flex items-center pl-[15px] md:pl-[25px] lg:pl-[30px] pr-[15px] md:pr-[25px] lg:pr-[30px] cursor-pointer"
                   >
@@ -262,6 +263,7 @@ const HeaderDashboard: React.FC<HeaderDashboardProps> = ({
             <div className="h-[34px] md:h-[38px] w-[1px] bg-[var(--color-gray3)]" />
             {/*유저 드롭다운 메뉴*/}
             <div
+              onMouseDown={(e) => e.stopPropagation()}
               onClick={() => setIsMenuOpen((prev) => !prev)}
               className="flex items-center gap-[12px] pl-[20px] md:pl-[30px] lg:pl-[35px] cursor-pointer overflow-hidden"
             >

--- a/src/components/gnb/MemberListMenu.tsx
+++ b/src/components/gnb/MemberListMenu.tsx
@@ -31,7 +31,7 @@ const MemberListMenu: React.FC<MemberListMenuProps> = ({
           : "opacity-0 -translate-y-2 pointer-events-none"
       )}
     >
-      <ul className="flex flex-col font-16r max-h-[300px] overflow-y-auto">
+      <ul className="flex flex-col font-16r max-h-[200px] sm:max-h-[270px] overflow-y-auto">
         {members.map((member) => (
           <li
             key={member.id}

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -83,7 +83,7 @@ export default function Input(props: InputProps) {
   };
 
   return (
-    <div className={clsx("flex flex-col items-start gap-2", wrapperClassName)}>
+    <div className={clsx("flex flex-col items-start gap-1", wrapperClassName)}>
       {label && (
         <label
           htmlFor={id}

--- a/src/components/sideMenu/SideMenu.tsx
+++ b/src/components/sideMenu/SideMenu.tsx
@@ -51,7 +51,8 @@ export default function SideMenu({
   return (
     <aside
       className={clsx(
-        "flex flex-col h-screen overflow-y-auto lg:overflow-y-hidden overflow-x-hidden border-r border-[var(--color-gray3)] px-3 py-5 transition-all duration-200",
+        "z-20 flex flex-col h-screen overflow-y-auto lg:overflow-y-hidden overflow-x-hidden transition-all duration-200",
+        "bg-white border-r border-[var(--color-gray3)] px-3 py-5",
         isCollapsed
           ? "w-[67px]"
           : "w-[67px] sm:w-[67px] md:w-[160px] lg:w-[300px]"

--- a/src/components/sideMenu/SideMenu.tsx
+++ b/src/components/sideMenu/SideMenu.tsx
@@ -132,7 +132,7 @@ export default function SideMenu({
           {/* 대시보드 타이틀 + 추가 버튼 */}
           {!isCollapsed && (
             <div className="mb-4 flex items-center justify-between px-3 md:px-2">
-              <span className="hidden md:block font-12sb text-[var(--color-black)]">
+              <span className="hidden md:block font-12sb text-[var(--color-gray1)]">
                 Dash Boards
               </span>
               <button

--- a/src/components/sideMenu/SideMenu.tsx
+++ b/src/components/sideMenu/SideMenu.tsx
@@ -34,7 +34,7 @@ export default function SideMenu({
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const itemsPerPage = 14;
+  const itemsPerPage = 15;
   const totalPages = Math.ceil(dashboardList.length / itemsPerPage);
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
@@ -224,7 +224,7 @@ export default function SideMenu({
 
         {/* 페이지네이션 */}
         {!isCollapsed && dashboardList.length > itemsPerPage && (
-          <div className="flex justify-start items-end mb-9 px-2">
+          <div className="flex justify-start items-end mb-1 px-2">
             <PaginationButton
               direction="left"
               disabled={currentPage === 1}

--- a/src/pages/dashboard/[dashboardId]/edit.tsx
+++ b/src/pages/dashboard/[dashboardId]/edit.tsx
@@ -69,7 +69,7 @@ export default function EditDashboard() {
         <HeaderDashboardEdit variant="edit" dashboardId={dashboardId} />
 
         <div
-          className="overflow-auto flex-1 px-[20px] pt-[10px] pb-10"
+          className="overflow-auto flex-1 px-6 pt-[10px] pb-10"
           style={{ backgroundColor: "#F5F2FC" }}
         >
           <div className="mt-6">

--- a/src/pages/dashboard/[dashboardId]/index.tsx
+++ b/src/pages/dashboard/[dashboardId]/index.tsx
@@ -111,7 +111,7 @@ export default function Dashboard() {
       <div className="flex flex-col flex-1 overflow-hidden">
         <HeaderDashboard variant="dashboard" dashboardId={dashboardId} />
 
-        <div className="flex-1 overflow-x-auto flex flex-col md:flex-col lg:flex-row bg-white">
+        <div className="flex-1 overflow-x-auto flex flex-col md:flex-col lg:flex-row bg-white pl-6 pt-6">
           {/* 각 칼럼 렌더링 */}
           {columns.map((col) => (
             <Column

--- a/src/pages/dashboard/[dashboardId]/index.tsx
+++ b/src/pages/dashboard/[dashboardId]/index.tsx
@@ -111,12 +111,17 @@ export default function Dashboard() {
       <div className="flex flex-col flex-1 overflow-hidden">
         <HeaderDashboard variant="dashboard" dashboardId={dashboardId} />
 
-        <main className="flex flex-1 flex-col min-h-0 overflow-x-auto lg:flex-row bg-white pl-6 pt-6">
+        <main
+          className="flex flex-1 flex-col min-h-0 lg:flex-row
+        bg-white pl-6 pt-6
+        overflow-y-auto"
+        >
           {/* 칼럼 가로 스크롤 영역 */}
           <div
             className="flex flex-col lg:flex-row
-          overflow-y-auto lg:overflow-x-auto
-          flex-1 min-h-0"
+          lg:overflow-x-auto
+          flex-1 min-h-0
+          w-[260px] sm:w-[560px]"
           >
             {/* 각 칼럼 렌더링 */}
             {columns.map((col) => (

--- a/src/pages/dashboard/[dashboardId]/index.tsx
+++ b/src/pages/dashboard/[dashboardId]/index.tsx
@@ -133,7 +133,7 @@ export default function Dashboard() {
               />
             ))}
             {/* ColumnsButton: 모바일/태블릿에서는 하단 고정, 데스크탑에서는 원래 위치 */}
-            <div className={`p-11 hidden lg:block bg-white`}>
+            <div className={`py-10 px-2 hidden lg:block bg-white`}>
               <ColumnsButton onClick={openModal} />
             </div>
           </div>
@@ -174,7 +174,7 @@ export default function Dashboard() {
         <div className="h-[100px] lg:hidden shrink-0" />
         {/* fixed 버튼 (모바일, 태블릿용) */}
         <div
-          className={`z-10 fixed bottom-0 left-0 w-full p-3 
+          className={`z-10 fixed bottom-0 left-[33px] md:left-[80px] w-full p-3
             bg-white border-t border-gray-200 
             flex justify-center lg:hidden`}
         >

--- a/src/pages/dashboard/[dashboardId]/index.tsx
+++ b/src/pages/dashboard/[dashboardId]/index.tsx
@@ -102,7 +102,7 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="flex h-screen overflow-hidden ">
+    <div className="flex h-screen overflow-hidden">
       <SideMenu
         teamId={TEAM_ID}
         dashboardList={dashboardList}
@@ -111,17 +111,25 @@ export default function Dashboard() {
       <div className="flex flex-col flex-1 overflow-hidden">
         <HeaderDashboard variant="dashboard" dashboardId={dashboardId} />
 
-        <div className="flex-1 overflow-x-auto flex flex-col md:flex-col lg:flex-row bg-white pl-6 pt-6">
-          {/* 각 칼럼 렌더링 */}
-          {columns.map((col) => (
-            <Column
-              key={col.id}
-              columnId={col.id}
-              title={col.title}
-              tasks={tasksByColumn[col.id] || []}
-              dashboardId={Number(dashboardId)}
-            />
-          ))}
+        <main className="flex flex-1 flex-col min-h-0 overflow-x-auto lg:flex-row bg-white pl-6 pt-6">
+          {/* 칼럼 가로 스크롤 영역 */}
+          <div
+            className="flex flex-col lg:flex-row
+          overflow-y-auto lg:overflow-x-auto
+          flex-1 min-h-0"
+          >
+            {/* 각 칼럼 렌더링 */}
+            {columns.map((col) => (
+              <Column
+                key={col.id}
+                columnId={col.id}
+                title={col.title}
+                tasks={tasksByColumn[col.id] || []}
+                dashboardId={Number(dashboardId)}
+              />
+            ))}
+          </div>
+
           {/* ColumnsButton: 모바일/태블릿에서는 하단 고정, 데스크탑에서는 원래 위치 */}
           <div className={`p-11 hidden lg:block bg-white`}>
             <ColumnsButton onClick={openModal} />
@@ -167,7 +175,7 @@ export default function Dashboard() {
               }}
             />
           )}
-        </div>
+        </main>
       </div>
     </div>
   );

--- a/src/pages/dashboard/[dashboardId]/index.tsx
+++ b/src/pages/dashboard/[dashboardId]/index.tsx
@@ -112,9 +112,8 @@ export default function Dashboard() {
         <HeaderDashboard variant="dashboard" dashboardId={dashboardId} />
 
         <main
-          className="flex flex-1 flex-col min-h-0 lg:flex-row
-        bg-white pl-6 pt-6
-        overflow-y-auto"
+          className="flex flex-1 flex-col min-h-0 lg:flex-row overflow-y-auto
+        bg-white pl-6 py-6"
         >
           {/* 칼럼 가로 스크롤 영역 */}
           <div
@@ -133,21 +132,12 @@ export default function Dashboard() {
                 dashboardId={Number(dashboardId)}
               />
             ))}
+            {/* ColumnsButton: 모바일/태블릿에서는 하단 고정, 데스크탑에서는 원래 위치 */}
+            <div className={`p-11 hidden lg:block bg-white`}>
+              <ColumnsButton onClick={openModal} />
+            </div>
           </div>
 
-          {/* ColumnsButton: 모바일/태블릿에서는 하단 고정, 데스크탑에서는 원래 위치 */}
-          <div className={`p-11 hidden lg:block bg-white`}>
-            <ColumnsButton onClick={openModal} />
-          </div>
-
-          {/* fixed 버튼 (모바일, 태블릿용) */}
-          <div
-            className={`
-    fixed bottom-0 left-0 w-full p-3 z-10 bg-white border-t border-gray-200
-    flex justify-center lg:hidden`}
-          >
-            <ColumnsButton onClick={openModal} />
-          </div>
           {/* 칼럼 추가 모달 */}
           {isAddColumnModalOpen && (
             <AddColumnModal
@@ -181,6 +171,15 @@ export default function Dashboard() {
             />
           )}
         </main>
+        <div className="h-[100px] lg:hidden shrink-0" />
+        {/* fixed 버튼 (모바일, 태블릿용) */}
+        <div
+          className={`z-10 fixed bottom-0 left-0 w-full p-3 
+            bg-white border-t border-gray-200 
+            flex justify-center lg:hidden`}
+        >
+          <ColumnsButton onClick={openModal} />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -48,7 +48,7 @@ export default function LoginPage() {
         <img
           src="/svgs/main-logo.svg"
           alt="태스키파이 로고 이미지"
-          className="w-[200px] h-[280px]"
+          className="w-[180px]"
         />
         <p className="font-20m text-black3">오늘도 만나서 반가워요!</p>
       </div>
@@ -64,6 +64,7 @@ export default function LoginPage() {
           placeholder="이메일을 입력해 주세요"
           onChange={handleChange("email")}
           invalidMessage="올바른 이메일 주소를 입력해 주세요"
+          className="bg-white"
         />
 
         <Input
@@ -74,6 +75,7 @@ export default function LoginPage() {
           onChange={handleChange("password")}
           pattern=".{8,}"
           invalidMessage="비밀번호는 8자 이상이어야 해요"
+          className="bg-white"
         />
 
         <button

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -55,19 +55,24 @@ export default function SignUpPage() {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-[var(--color-gray5)] py-10">
-      <div className="text-center mb-[40px]">
+    <div
+      className="flex flex-col min-h-screen
+    items-center justify-center
+    bg-[var(--color-gray5)] py-10"
+    >
+      <div className="text-center mb-[25px]">
         <img
           src="/svgs/main-logo.svg"
           alt="태스키파이 로고 이미지"
-          className="w-[200px] h-[280px] relative"
+          className="w-[180px] relative"
         />
         <p className="font-20m text-black3">첫 방문을 환영합니다!</p>
       </div>
 
       <form
         onSubmit={handleSubmit}
-        className="flex flex-col w-[350px] md:w-[520px] gap-[20px] font-16r text-black3"
+        className="flex flex-col w-[350px] md:w-[520px] gap-[18px]
+        font-16r text-black3"
       >
         <Input
           type="email"
@@ -77,6 +82,7 @@ export default function SignUpPage() {
           onChange={setEmail}
           pattern="^[\w.-]+@[\w.-]+\.\w{2,}$"
           invalidMessage="올바른 이메일 주소를 입력해 주세요"
+          className="bg-white"
         />
 
         <Input
@@ -85,6 +91,7 @@ export default function SignUpPage() {
           label="닉네임"
           placeholder="닉네임을 입력해 주세요"
           onChange={setNickname}
+          className="bg-white"
         />
 
         <Input
@@ -95,6 +102,7 @@ export default function SignUpPage() {
           onChange={setPassword}
           pattern=".{8,}"
           invalidMessage="영문, 숫자를 포함한 8자 이상 입력해 주세요"
+          className="bg-white"
         />
 
         <Input
@@ -105,6 +113,7 @@ export default function SignUpPage() {
           onChange={setPasswordCheck}
           pattern="{passwordCheckPattern}"
           invalidMessage="비밀번호가 일치하지 않습니다."
+          className="bg-white"
         />
 
         <label className="flex items-center gap-[8px] font-16r text-black3">


### PR DESCRIPTION
## 작업 내용
1. Column: 가로 스크롤 제거 / 디자인 변경_여백 & 반응형 조정
2. dashboardindex_ColumnsButton: 하단 고정 버튼이 사이드메뉴 위로 오는 문제 수정 / 중앙 정렬 설정
3. SideMenu: 맨 위로 오게 하기 위해 z-20 추가
4. signup_Input: 회원가입 페이지 스크롤 제거 목적, 인풋 라벨 gap 1로 조정
5. Card: 제목 생략 모바일에 적용 안 됨, max-w 추가해 적용 / text 색상 & 사이즈 수정
6. HeaderDashboard_UserMenu, MemberListMenu: 메뉴 열린 상태에서 onClick 재실행 시 닫히도록 변경