### PR TITLE
[Fix] mypage: api 요청 무한 루프 에러 수정

### DIFF
--- a/src/components/card/ChangePassword.tsx
+++ b/src/components/card/ChangePassword.tsx
@@ -1,11 +1,9 @@
 import { useState } from "react";
-import { useRouter } from "next/router";
 import { changePassword } from "@/api/changepassword";
 import Input from "@/components/input/Input";
 import { toast } from "react-toastify";
 
 export default function ChangePassword() {
-  const router = useRouter();
   const [password, setPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [checkNewpassword, setCheckNewPassword] = useState("");

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -40,11 +40,10 @@ export default function MyPage() {
   };
 
   useEffect(() => {
-    if (isInitialized && user) {
+    if (isInitialized) {
       fetchDashboards();
-      fetchUserData();
     }
-  }, [isInitialized, user]);
+  }, [isInitialized]);
 
   if (!isInitialized || !user) {
     return <LoadingSpinner />;


### PR DESCRIPTION
## 작업 내용

useEffect(() => {
  if (isInitialized && user) {
    fetchDashboards();
    fetchUserData();
  }
}, [isInitialized, user]);

user 상태 변경 연쇄 현상으로 useEffect가 무한 실행되는 에러 발견
의존성 배열에서 user 제거해서 fix,
Profile 컴포넌트에서 이미 실행하는 fetchUserData();도 불필요해 제거함.