### PR TITLE
[Feat, Refector] D&D 적용 및 파일수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "taskify",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
         "@tanstack/react-query": "^5.68.0",
         "axios": "^1.8.3",
         "clsx": "^2.1.1",
@@ -55,6 +58,73 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
     "@tanstack/react-query": "^5.68.0",
     "axios": "^1.8.3",
     "clsx": "^2.1.1",

--- a/src/components/button/CardButton.tsx
+++ b/src/components/button/CardButton.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import clsx from "clsx";
 import Image from "next/image";
 
-interface CardButtonProps extends React.ButtonHTMLAttributes<HTMLDivElement> {
+interface CardButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   title?: string;
   showCrown?: boolean;
   color?: string;
@@ -12,29 +12,29 @@ interface CardButtonProps extends React.ButtonHTMLAttributes<HTMLDivElement> {
   createdByMe?: boolean;
   onDeleteClick?: (id: number) => void;
   onLeaveClick?: (id: number) => void;
+  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 const CardButton: React.FC<CardButtonProps> = ({
   className,
   title = "비브리지",
   showCrown = true,
-  color = "#7ac555", // 기본 색상
+  color = "#7ac555",
   isEditMode = false,
   dashboardId,
   createdByMe,
   onDeleteClick,
   onLeaveClick,
+  dragHandleProps,
   ...props
 }) => {
   const router = useRouter();
 
   const handleCardClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    // 관리 상태에서 카드 클릭 이벤트 차단
     if (isEditMode) {
       e.preventDefault();
       return;
     }
-    // 카드 클릭 시 해당 대시보드로 이동
     router.push(`/dashboard/${dashboardId}`);
   };
 
@@ -46,11 +46,9 @@ const CardButton: React.FC<CardButtonProps> = ({
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (createdByMe) {
-      // 실제 삭제 API 요청
-      if (onDeleteClick) onDeleteClick(dashboardId);
+      onDeleteClick?.(dashboardId);
     } else {
-      // 나만 탈퇴
-      if (onLeaveClick) onLeaveClick(dashboardId);
+      onLeaveClick?.(dashboardId);
     }
   };
 
@@ -64,7 +62,7 @@ const CardButton: React.FC<CardButtonProps> = ({
         "border border-[var(--color-gray3)]",
         "min-w-0 w-full max-w-[260px] md:max-w-[247px] lg:max-w-[332px]",
         "h-[58px] md:h-[68px] lg:h-[70px]",
-        "mt-[2px]", // 카드 세로 간격
+        "mt-[2px]",
         "text-lg md:text-2lg lg:text-2lg",
         isEditMode
           ? "cursor-default hover:border-gray-300"
@@ -74,30 +72,25 @@ const CardButton: React.FC<CardButtonProps> = ({
     >
       {/* 왼쪽: 색상 도트 + 제목 + 왕관 */}
       <div className="flex items-center overflow-hidden font-semibold gap-[10px]">
-        {/* 색상 원 */}
         <svg width="8" height="8" viewBox="0 0 8 8" fill={color}>
           <circle cx="4" cy="4" r="4" />
         </svg>
-
-        {/* 제목 */}
         <span className="text-black3 text-[14px] sm:text-[16px] truncate max-w-[120px]">
           {title}
         </span>
-
-        {/* 왕관 */}
-        <div className="relative w-[15px] h-[12px] md:w-[17px] md:h-[14px]">
-          {showCrown && (
+        {showCrown && (
+          <div className="relative w-[15px] h-[12px] md:w-[17px] md:h-[14px]">
             <Image
               src="/svgs/icon-crown.svg"
               alt="crown Icon"
               fill
               className="object-contain"
             />
-          )}
-        </div>
+          </div>
+        )}
       </div>
 
-      {/* 오른쪽: 화살표 아이콘 or 수정/삭제 버튼 */}
+      {/* 오른쪽: 수정/삭제 버튼 or 드래그 핸들 */}
       {isEditMode ? (
         <div className="flex flex-col gap-2">
           {createdByMe && (
@@ -116,13 +109,15 @@ const CardButton: React.FC<CardButtonProps> = ({
           </button>
         </div>
       ) : (
-        <Image
-          src="/svgs/arrow-forward-black.svg"
-          alt="arrow icon"
-          width={16}
-          height={16}
-          className="ml-2"
-        />
+        <div {...dragHandleProps}>
+          <Image
+            src="/svgs/arrow-forward-black.svg"
+            alt="arrow icon"
+            width={16}
+            height={16}
+            className="ml-2 cursor-grab active:cursor-grabbing"
+          />
+        </div>
       )}
     </div>
   );

--- a/src/components/button/CardButton.tsx
+++ b/src/components/button/CardButton.tsx
@@ -12,7 +12,8 @@ interface CardButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   createdByMe?: boolean;
   onDeleteClick?: (id: number) => void;
   onLeaveClick?: (id: number) => void;
-  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>;
+  attributes?: React.HTMLAttributes<HTMLDivElement>;
+  listeners?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 const CardButton: React.FC<CardButtonProps> = ({
@@ -25,7 +26,8 @@ const CardButton: React.FC<CardButtonProps> = ({
   createdByMe,
   onDeleteClick,
   onLeaveClick,
-  dragHandleProps,
+  attributes,
+  listeners,
   ...props
 }) => {
   const router = useRouter();
@@ -54,6 +56,8 @@ const CardButton: React.FC<CardButtonProps> = ({
 
   return (
     <div
+      {...attributes}
+      {...listeners}
       {...props}
       onClick={handleCardClick}
       className={clsx(
@@ -90,7 +94,7 @@ const CardButton: React.FC<CardButtonProps> = ({
         )}
       </div>
 
-      {/* 오른쪽: 수정/삭제 버튼 or 드래그 핸들 */}
+      {/* 오른쪽: 수정/삭제 버튼 또는 아이콘 */}
       {isEditMode ? (
         <div className="flex flex-col gap-2">
           {createdByMe && (
@@ -109,15 +113,13 @@ const CardButton: React.FC<CardButtonProps> = ({
           </button>
         </div>
       ) : (
-        <div {...dragHandleProps}>
-          <Image
-            src="/svgs/arrow-forward-black.svg"
-            alt="arrow icon"
-            width={16}
-            height={16}
-            className="ml-2 cursor-grab active:cursor-grabbing"
-          />
-        </div>
+        <Image
+          src="/svgs/arrow-forward-black.svg"
+          alt="arrow icon"
+          width={16}
+          height={16}
+          className="ml-2"
+        />
       )}
     </div>
   );

--- a/src/components/button/SortableCardButton.tsx
+++ b/src/components/button/SortableCardButton.tsx
@@ -1,0 +1,39 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import CardButton from "./CardButton";
+import { Dashboard } from "@/api/dashboards";
+
+export default function SortableCardButton({
+  dashboard,
+  ...rest
+}: {
+  dashboard: Dashboard;
+  isEditMode?: boolean;
+  onDeleteClick?: (id: number) => void;
+  onLeaveClick?: (id: number) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({
+      id: dashboard.id,
+    });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: 10,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <CardButton
+        dashboardId={dashboard.id}
+        title={dashboard.title}
+        showCrown={dashboard.createdByMe}
+        color={dashboard.color}
+        createdByMe={dashboard.createdByMe}
+        {...rest}
+        dragHandleProps={{ ...attributes, ...listeners }}
+      />
+    </div>
+  );
+}

--- a/src/components/button/SortableCardButton.tsx
+++ b/src/components/button/SortableCardButton.tsx
@@ -32,7 +32,8 @@ export default function SortableCardButton({
         color={dashboard.color}
         createdByMe={dashboard.createdByMe}
         {...rest}
-        dragHandleProps={{ ...attributes, ...listeners }}
+        attributes={attributes}
+        listeners={listeners}
       />
     </div>
   );

--- a/src/pages/mydashboard.tsx
+++ b/src/pages/mydashboard.tsx
@@ -5,7 +5,6 @@ import { getDashboards } from "@/api/dashboards";
 import { useAuthGuard } from "@/hooks/useAuthGuard";
 import SideMenu from "@/components/sideMenu/SideMenu";
 import HeaderDashboard from "@/components/gnb/HeaderDashboard";
-import CardButton from "@/components/button/CardButton";
 import DashboardAddButton from "@/components/button/DashboardAddButton";
 import { PaginationButton } from "@/components/button/PaginationButton";
 import InvitedDashBoard from "@/components/table/invited/InvitedDashBoard";
@@ -15,6 +14,20 @@ import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { TEAM_ID } from "@/constants/team";
 import { Search } from "lucide-react";
 import { toast } from "react-toastify";
+
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  rectSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import SortableCardButton from "@/components/button/SortableCardButton";
 
 interface Dashboard {
   id: number;
@@ -45,6 +58,8 @@ export default function MyDashboardPage() {
     useState(false);
   const itemsPerPage = 6;
 
+  const sensors = useSensors(useSensor(PointerSensor));
+
   const filteredDashboardList = dashboardList.filter((dashboard) =>
     dashboard.title.toLowerCase().includes(searchKeyword.toLowerCase())
   );
@@ -53,33 +68,6 @@ export default function MyDashboardPage() {
     (filteredDashboardList.length + 1) / itemsPerPage
   );
   const startIndex = (currentPage - 1) * itemsPerPage;
-
-  const currentItems = [
-    <DashboardAddButton key="add" onClick={() => setIsModalOpen(true)} />,
-    ...filteredDashboardList.map((dashboard) => (
-      <CardButton
-        key={dashboard.id}
-        dashboardId={dashboard.id}
-        title={dashboard.title}
-        showCrown={dashboard.createdByMe}
-        color={dashboard.color}
-        isEditMode={isEditMode}
-        createdByMe={dashboard.createdByMe}
-        onDeleteClick={(id) => {
-          setSelectedDashboardId(id);
-          setSelectedCreatedByMe(true);
-          setSelectedTitle(dashboard.title);
-          setIsDeleteModalOpen(true);
-        }}
-        onLeaveClick={(id) => {
-          setSelectedDashboardId(id);
-          setSelectedCreatedByMe(false);
-          setSelectedTitle(dashboard.title);
-          setIsDeleteModalOpen(true);
-        }}
-      />
-    )),
-  ].slice(startIndex, startIndex + itemsPerPage);
 
   const fetchDashboards = async () => {
     try {
@@ -125,6 +113,17 @@ export default function MyDashboardPage() {
     setSelectedDashboardId(null);
   };
 
+  const handleDragEnd = (event: any) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = dashboardList.findIndex((d) => d.id === active.id);
+    const newIndex = dashboardList.findIndex((d) => d.id === over.id);
+
+    const newOrder = arrayMove(dashboardList, oldIndex, newIndex);
+    setDashboardList(newOrder);
+  };
+
   if (!isInitialized || !user) {
     return <LoadingSpinner />;
   }
@@ -145,7 +144,6 @@ export default function MyDashboardPage() {
         />
 
         <main className="flex-col overflow-auto px-6 py-5 sm:py-10 bg-[#F5F2FC]">
-          {/* 검색 입력창 */}
           <section className="w-full overflow-hidden transition-all">
             <div className="min-w-0 w-full max-w-[260px] md:max-w-[247px] lg:max-w-[332px] mb-3">
               <div className="relative flex items-center justify-end">
@@ -169,12 +167,45 @@ export default function MyDashboardPage() {
           </section>
 
           <section className="w-full max-w-[260px] sm:max-w-[504px] lg:max-w-[1022px]">
-            {/* 카드 영역 */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[8px] md:gap-[10px] lg:gap-[13px]">
-              {currentItems.map((item, index) => (
-                <div key={index}>{item}</div>
-              ))}
-            </div>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={dashboardList.map((d) => d.id)}
+                strategy={rectSortingStrategy}
+              >
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[8px] md:gap-[10px] lg:gap-[13px]">
+                  <div key="add">
+                    <DashboardAddButton onClick={() => setIsModalOpen(true)} />
+                  </div>
+
+                  {filteredDashboardList
+                    .slice(startIndex, startIndex + (itemsPerPage - 1))
+                    .map((dashboard) => (
+                      <SortableCardButton
+                        key={dashboard.id}
+                        dashboard={dashboard}
+                        isEditMode={isEditMode}
+                        onDeleteClick={(id: number) => {
+                          setSelectedDashboardId(id);
+                          setSelectedCreatedByMe(true);
+                          setSelectedTitle(dashboard.title);
+                          setIsDeleteModalOpen(true);
+                        }}
+                        onLeaveClick={(id: number) => {
+                          setSelectedDashboardId(id);
+                          setSelectedCreatedByMe(false);
+                          setSelectedTitle(dashboard.title);
+                          setIsDeleteModalOpen(true);
+                        }}
+                      />
+                    ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+
             {totalPages > 1 && (
               <div className="w-full flex justify-end items-center mt-3">
                 <span className="text-[12px] sm:text-[14px] text-black3 px-[8px] whitespace-nowrap">
@@ -192,7 +223,7 @@ export default function MyDashboardPage() {
                 />
               </div>
             )}
-            {/* 초대받은 대시보드 */}
+
             <div className="mt-[25px]">
               <InvitedDashBoard />
             </div>

--- a/src/pages/mydashboard.tsx
+++ b/src/pages/mydashboard.tsx
@@ -58,7 +58,13 @@ export default function MyDashboardPage() {
     useState(false);
   const itemsPerPage = 6;
 
-  const sensors = useSensors(useSensor(PointerSensor));
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 5,
+      },
+    })
+  );
 
   const filteredDashboardList = dashboardList.filter((dashboard) =>
     dashboard.title.toLowerCase().includes(searchKeyword.toLowerCase())


### PR DESCRIPTION
## 작업 내용

- 나의 대쉬보드 페이지에 D&D 를 적용하였습니다. 
- 대시보드 이동 클릭과 드래그 충돌 방지를 위해  distance: 5 5px 이상 이동시 드래그 되도록 하였습니다.
- SortableCardButton.tsx 를 새로 작성하여 dragHandleProps → attributes, listeners props 전달 방식을 변경하였습니다.

## 주의 사항
- 아직 D&D로 변경된 순서를 api에 저장하지는 못합니다. 추후 수정예정
- npm install @dnd-kit/core @dnd-kit/sortable @dnd-kit/modifiers 부탁드리겟습니다.
