### PR TITLE
[Style, Refactor] Column: 카드리스트 스크롤 칼럼으로 이동 / Card: 반응형 디자인 수정

### DIFF
--- a/src/components/button/TodoButton.tsx
+++ b/src/components/button/TodoButton.tsx
@@ -5,7 +5,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   fullWidth?: boolean;
 }
 
-const TodoButton: React.FC<ButtonProps> = ({
+export const TodoButton: React.FC<ButtonProps> = ({
   fullWidth = false,
   className,
   children,
@@ -34,4 +34,23 @@ const TodoButton: React.FC<ButtonProps> = ({
   );
 };
 
-export default TodoButton;
+export const ShortTodoButton = () => {
+  return (
+    <button
+      className={clsx(
+        "flex justify-center items-center transition-all",
+        "cursor-pointer"
+      )}
+    >
+      <span
+        className={clsx(
+          "flex items-center justify-center leading-none",
+          "w-[20px] h-[20px] bg-white hover:bg-[var(--color-gray3)]",
+          "rounded-md text-[var(--primary)] font-medium text-[18px]"
+        )}
+      >
+        +
+      </span>
+    </button>
+  );
+};

--- a/src/components/columnCard/Card.tsx
+++ b/src/components/columnCard/Card.tsx
@@ -30,10 +30,11 @@ export default function Card({
           className={`
             mb-2 md:mb-0 md:mr-4 lg:mr-0
             shrink-0
-            w-full h-40
-            md:w-[91px] md:h-[53px]
-            lg:w-full lg:h-40
-          `}
+            w-full lg:w-full
+            lg:max-w-[100%] max-w-[77%]
+            lg:h-40 md:h-[53px] h-25
+            md:w-[90px]
+            `}
         >
           <Image
             className="rounded-md object-cover w-full h-full"
@@ -51,7 +52,7 @@ export default function Card({
           className={`
             text-black3 text-[14px] font-medium mt-2
             md:text-[16px] md:mt-0 lg:mt-2
-            truncate max-w-[180px] sm:max-w-none
+            truncate max-w-[190px] sm:max-w-[480px]
           `}
         >
           {title}
@@ -85,7 +86,7 @@ export default function Card({
           </div>
 
           {/* 날짜 + 닉네임 */}
-          <div className="flex items-center gap-2 md:gap-3 text-gray-500">
+          <div className="flex items-center gap-[29.5px] md:gap-3 sm:pr-4 text-[var(--color-gray1)]">
             <div className="flex items-center gap-1">
               <Image
                 src="/svgs/calendar.svg"

--- a/src/components/columnCard/Card.tsx
+++ b/src/components/columnCard/Card.tsx
@@ -105,7 +105,7 @@ export default function Card({
                 className="w-6 h-6 rounded-full object-cover"
               />
             ) : (
-              <div className="w-6 h-6 flex items-center justify-center bg-[#A3C4A2] text-white font-bold rounded-full text-xs">
+              <div className="w-6 h-6 flex items-center justify-center bg-[#A3C4A2] text-white font-medium rounded-full text-xs">
                 {assignee.nickname[0]}
               </div>
             )}

--- a/src/components/columnCard/CardList.tsx
+++ b/src/components/columnCard/CardList.tsx
@@ -80,7 +80,7 @@ export const CardList = ({
         items={cards.map((card) => card.id)}
         strategy={verticalListSortingStrategy}
       >
-        <div className="grid gap-3 w-full grid-cols-1">
+        <div className="w-full grid grid-cols-1 box-border gap-3 px-2">
           {cards.map((card) => (
             <SortableCard key={card.id} card={card} onClick={onCardClick} />
           ))}

--- a/src/components/columnCard/CardList.tsx
+++ b/src/components/columnCard/CardList.tsx
@@ -80,7 +80,10 @@ export const CardList = ({
         items={cards.map((card) => card.id)}
         strategy={verticalListSortingStrategy}
       >
-        <div className="w-full grid grid-cols-1 box-border gap-3 px-2">
+        <div
+          className="w-full grid grid-cols-1 box-border gap-3
+        px-0 lg:px-1.5"
+        >
           {cards.map((card) => (
             <SortableCard key={card.id} card={card} onClick={onCardClick} />
           ))}

--- a/src/components/columnCard/Column.tsx
+++ b/src/components/columnCard/Column.tsx
@@ -158,7 +158,7 @@ export default function Column({
 
       {/* 카드 리스트 */}
       <div
-        className="flex-1 overflow-y-auto overflow-x-hidden pr-2"
+        className="flex-1 overflow-y-auto overflow-x-hidden"
         style={{ scrollbarGutter: "stable" }}
       >
         <CardList

--- a/src/components/columnCard/Column.tsx
+++ b/src/components/columnCard/Column.tsx
@@ -1,5 +1,5 @@
 // Column.tsx
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import Image from "next/image";
 import { CardType } from "@/types/task";
 import TodoModal from "@/components/modalInput/ToDoModal";
@@ -41,6 +41,9 @@ export default function Column({
   const [members, setMembers] = useState<
     { id: number; userId: number; nickname: string }[]
   >([]);
+
+  // 카드리스트의 스크롤을 칼럼 영역으로 이동
+  const scrollRef = useRef<HTMLDivElement | null>(null);
 
   // ✅ 멤버 불러오기
   useEffect(() => {
@@ -105,9 +108,9 @@ export default function Column({
   return (
     <div
       className={`
-      flex flex-col shrink-0 overflow-hidden p-4 mr-4 lg:my-0 mb-4
+      flex flex-col shrink-0 lg:items-center overflow-hidden p-4 mr-4 lg:my-0 mb-4
       border border-[var(--color-gray4)] bg-[#F5F2FC] rounded-[12px]
-      w-full lg:w-[360px] max-h-[325px] lg:max-h-[830px]
+      w-full lg:w-[370px] max-h-[325px] lg:max-h-[830px]
       `}
     >
       {/* 칼럼 헤더 */}
@@ -156,17 +159,22 @@ export default function Column({
         </div>
       </div>
 
-      {/* 카드 리스트 */}
-      <div
-        className="flex-1 overflow-y-auto overflow-x-hidden"
-        style={{ scrollbarGutter: "stable" }}
-      >
-        <CardList
-          columnId={columnId}
-          teamId={TEAM_ID}
-          initialTasks={tasks}
-          onCardClick={(card) => handleCardClick(card.id)}
-        />
+      {/* 스크롤바 컨테이너 */}
+      <div className="flex flex-col lg:pl-[6.8px] overflow-y-auto w-full lg:w-[357px] rounded-[12px] bg-[#F5F2FC]">
+        {/* 카드 리스트 */}
+        <div
+          className="flex-1 overflow-y-auto overflow-x-hidden"
+          style={{ scrollbarGutter: "stable both-edges" }}
+          ref={scrollRef}
+        >
+          <CardList
+            columnId={columnId}
+            teamId={TEAM_ID}
+            initialTasks={tasks}
+            onCardClick={(card) => handleCardClick(card.id)}
+            scrollRoot={scrollRef}
+          />
+        </div>
       </div>
 
       {/* Todo 모달 */}

--- a/src/components/columnCard/Column.tsx
+++ b/src/components/columnCard/Column.tsx
@@ -107,7 +107,7 @@ export default function Column({
       className={`
       flex flex-col shrink-0 overflow-hidden p-4 mr-4 lg:my-0 mb-4
       border border-[var(--color-gray4)] bg-[#F5F2FC] rounded-[12px]
-      max-h-[325px] lg:max-h-none w-full lg:w-[360px]
+      w-full lg:w-[360px] max-h-[325px] lg:max-h-[830px]
       `}
     >
       {/* 칼럼 헤더 */}
@@ -146,29 +146,27 @@ export default function Column({
             </div>
           </div>
         </div>
+        <div className="flex items-center justify-center">
+          <div
+            onClick={() => setIsTodoModalOpen(true)}
+            className="mb-2 hidden lg:block"
+          >
+            <TodoButton />
+          </div>
+        </div>
       </div>
 
-      {/* 카드 영역 */}
-      <div className="flex-1 flex flex-col overflow-hidden items-center gap-2">
-        <div
-          onClick={() => setIsTodoModalOpen(true)}
-          className="mb-2 hidden lg:block"
-        >
-          <TodoButton />
-        </div>
-
-        {/* 카드 리스트 */}
-        <div
-          className="flex-1 w-full overflow-y-auto overflow-x-hidden"
-          style={{ scrollbarGutter: "stable" }}
-        >
-          <CardList
-            columnId={columnId}
-            teamId={TEAM_ID}
-            initialTasks={tasks}
-            onCardClick={(card) => handleCardClick(card.id)}
-          />
-        </div>
+      {/* 카드 리스트 */}
+      <div
+        className="flex-1 overflow-y-auto overflow-x-hidden pr-2"
+        style={{ scrollbarGutter: "stable" }}
+      >
+        <CardList
+          columnId={columnId}
+          teamId={TEAM_ID}
+          initialTasks={tasks}
+          onCardClick={(card) => handleCardClick(card.id)}
+        />
       </div>
 
       {/* Todo 모달 */}

--- a/src/components/columnCard/Column.tsx
+++ b/src/components/columnCard/Column.tsx
@@ -110,7 +110,7 @@ export default function Column({
       className={`
       flex flex-col shrink-0 lg:items-center overflow-hidden p-4 mr-4 lg:my-0 mb-4
       border border-[var(--color-gray4)] bg-[#F5F2FC] rounded-[12px]
-      w-full lg:w-[370px] max-h-[325px] lg:max-h-[830px]
+      w-full lg:w-[370px] max-h-[325px] lg:max-h-[827px]
       `}
     >
       {/* 칼럼 헤더 */}
@@ -160,11 +160,11 @@ export default function Column({
       </div>
 
       {/* 스크롤바 컨테이너 */}
-      <div className="flex flex-col lg:pl-[6.8px] overflow-y-auto w-full lg:w-[357px] rounded-[12px] bg-[#F5F2FC]">
+      <div className="flex flex-col lg:pl-[21px] overflow-y-auto w-full lg:w-[357px] rounded-[12px] bg-[#F5F2FC]">
         {/* 카드 리스트 */}
         <div
           className="flex-1 overflow-y-auto overflow-x-hidden"
-          style={{ scrollbarGutter: "stable both-edges" }}
+          style={{ scrollbarGutter: "stable" }}
           ref={scrollRef}
         >
           <CardList

--- a/src/components/columnCard/Column.tsx
+++ b/src/components/columnCard/Column.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import Image from "next/image";
 import { CardType } from "@/types/task";
 import TodoModal from "@/components/modalInput/ToDoModal";
-import TodoButton from "@/components/button/TodoButton";
+import { TodoButton, ShortTodoButton } from "@/components/button/TodoButton";
 import ColumnManageModal from "@/components/columnCard/ColumnManageModal";
 import ColumnDeleteModal from "@/components/columnCard/ColumnDeleteModal";
 import { updateColumn, deleteColumn } from "@/api/columns";
@@ -107,36 +107,53 @@ export default function Column({
       className={`
       flex flex-col shrink-0 overflow-hidden p-4 mr-4 lg:my-0 mb-4
       border border-[var(--color-gray4)] bg-[#F5F2FC] rounded-[12px]
-      max-h-[401px] lg:max-h-none w-full lg:w-[360px]
+      max-h-[325px] lg:max-h-none w-full lg:w-[360px]
       `}
     >
       {/* 칼럼 헤더 */}
-      <div className="shrink-0">
+      <div className="shrink-0 mb-2">
         <div className="flex items-center justify-between">
+          {/* 왼쪽: 타이틀 + 카드 개수 */}
           <div className="flex items-center gap-2">
             <Image src="/svgs/ellipse.svg" alt="circle" width={8} height={8} />
             <h2 className="text-black3 text-[16px] md:text-[18px] font-bold">
               {columnTitle}
             </h2>
-            <span className="w-5 h-5 text-sm bg-gray-200 text-gray-700 rounded-[4px] flex items-center justify-center ">
+            <span
+              className="flex items-center justify-center leading-none
+            w-[20px] h-[20px] bg-white text-[var(--primary)] font-14m rounded-[4px]"
+            >
               {tasks.length}
             </span>
           </div>
-          <Image
-            src="/svgs/settings.svg"
-            alt="setting icon"
-            width={24}
-            height={24}
-            priority
-            className="cursor-pointer"
-            onClick={() => setIsColumnModalOpen(true)}
-          />
+          {/* 오른쪽: 생성 버튼 + 설정 버튼 */}
+          <div className="flex items-center gap-2">
+            <div
+              onClick={() => setIsTodoModalOpen(true)}
+              className="block lg:hidden"
+            >
+              <ShortTodoButton />
+            </div>
+            <div className="relative flex justify-end w-[22px] sm:w-[24px] h-[22px] sm:h-[24px]">
+              <Image
+                src="/svgs/settings.svg"
+                alt="setting icon"
+                fill
+                priority
+                className="object-contain cursor-pointer"
+                onClick={() => setIsColumnModalOpen(true)}
+              />
+            </div>
+          </div>
         </div>
       </div>
 
       {/* 카드 영역 */}
-      <div className="flex-1 flex flex-col overflow-hidden items-center pb-4 gap-2">
-        <div onClick={() => setIsTodoModalOpen(true)} className="mb-2">
+      <div className="flex-1 flex flex-col overflow-hidden items-center gap-2">
+        <div
+          onClick={() => setIsTodoModalOpen(true)}
+          className="mb-2 hidden lg:block"
+        >
           <TodoButton />
         </div>
 

--- a/src/components/modalDashboard/CardDetailModal.tsx
+++ b/src/components/modalDashboard/CardDetailModal.tsx
@@ -194,7 +194,7 @@ export default function CardDetailPage({
               });
 
               if (onChangeCard) onChangeCard();
-              onClose();
+              setIsEditModalOpen(false);
               toast.success("카드가 수정되었습니다.");
             } catch (err) {
               console.error("카드 수정 실패:", err);

--- a/src/components/modalInput/AssigneeSelect.tsx
+++ b/src/components/modalInput/AssigneeSelect.tsx
@@ -45,7 +45,7 @@ export default function AssigneeSelect({
       {label && (
         <p className="text-black3 font-medium text-[14px] sm:text-[18px]">
           {label}
-          {required && <span className="text-[var(--color-purple)]"> *</span>}
+          {required && <span className="text-[var(--primary)]"> *</span>}
         </p>
       )}
 

--- a/src/components/modalInput/ModalInput.tsx
+++ b/src/components/modalInput/ModalInput.tsx
@@ -182,8 +182,7 @@ export default function ModalInput({
   return (
     <div className="inline-flex flex-col items-start gap-2.5 w-full">
       <p className={inputClassNames.label}>
-        {label}{" "}
-        {required && <span className="text-[var(--color-purple)]"> *</span>}
+        {label} {required && <span className="text-[var(--primary)]"> *</span>}
       </p>
       <div className="w-full">{inputElement}</div>
     </div>

--- a/src/components/modalInput/StatusSelect.tsx
+++ b/src/components/modalInput/StatusSelect.tsx
@@ -67,7 +67,7 @@ export default function StatusSelect({
       {label && (
         <p className="text-black3 font-medium text-[14px] sm:text-[18px]">
           {label}
-          {required && <span className="text-[var(--color-purple)]"> *</span>}
+          {required && <span className="text-[var(--primary)]"> *</span>}
         </p>
       )}
 

--- a/src/pages/dashboard/[dashboardId]/index.tsx
+++ b/src/pages/dashboard/[dashboardId]/index.tsx
@@ -101,7 +101,7 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="flex h-screen overflow-hidden">
+    <div className="flex min-h-screen">
       <SideMenu
         teamId={TEAM_ID}
         dashboardList={dashboardList}
@@ -111,7 +111,8 @@ export default function Dashboard() {
         <HeaderDashboard variant="dashboard" dashboardId={dashboardId} />
 
         <main
-          className="flex flex-1 flex-col min-h-0 lg:flex-row overflow-y-auto
+          className="flex flex-1 flex-col lg:flex-row
+          overflow-y-auto min-h-0
         bg-white px-6 py-6"
         >
           {/* 칼럼 가로 스크롤 영역 */}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -43,7 +43,7 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center h-screen bg-[var(--color-gray5)] py-10">
+    <div className="flex flex-col items-center justify-center h-screen bg-white py-10">
       <div className="text-center mb-[40px]">
         <img
           src="/svgs/main-logo.svg"

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -58,7 +58,7 @@ export default function SignUpPage() {
     <div
       className="flex flex-col min-h-screen
     items-center justify-center
-    bg-[var(--color-gray5)] py-10"
+    bg-white py-10"
     >
       <div className="text-center mb-[25px]">
         <img

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -28,7 +28,7 @@
   background-color: #f3f0ff !important;
   padding: 14px 18px;
   font-size: 14px;
-  font-weight: 400;
+  font-weight: 500;
 }
 
 .Toastify__toast--success {
@@ -37,7 +37,6 @@
   background-color: #f3f0ff !important;
   color: #5534da !important;
   font-size: 14px;
-  font-weight: 400;
   box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
 }
 
@@ -47,7 +46,6 @@
   background-color: white !important;
   color: #d549b6 !important;
   font-size: 14px;
-  font-weight: 400;
   box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
 }
 


### PR DESCRIPTION
## 작업 내용
1. Column, CardList: 카드리스트 내부 스크롤을 칼럼에 적용(스크롤에 카드 오른쪽이 잘려 보이는 현상 해결 목적)
2. Card: 미리보기 이미지 크기, 내부 아이템 여백 등 반응형 디자인 수정
3. ModalInput: 필수 입력값 표시 '*' 색상 통일(기존 바이올렛, 프라이머리 혼용됨)
4. toast: text 두께 r -> m 변경
5. login, signup: 배경색 gray -> white 변경