### PR TITLE
[Fix] 랜딩페이지 정렬 수정

### DIFF
--- a/src/components/landing/LandingMain.tsx
+++ b/src/components/landing/LandingMain.tsx
@@ -9,19 +9,18 @@ export default function LandingMain() {
       <Section1 />
 
       {/* Section2와 Section3 영역 */}
-      <div className="md:mt-[180px] mt-[80px] md:mb-[160px] mb-[80px] w-full max-w-[1200px] flex flex-col items-center">
+      <div className="md:mt-[180px] mt-[80px] md:mb-[160px] mb-[80px] w-full flex flex-col items-center">
         {/* Section2: 우선순위 & 해야 할 일 등록 */}
         <Section2 />
 
-        {/* Section3 영역 시작 */}
-        <div className="mt-[120px] w-full flex flex-col gap-[36px]">
-          {/* 타이틀: 왼쪽 정렬 + 28px */}
-          <p className="text-[28px] font-bold leading-[42px] text-[var(--color-white)]">
+        {/* Section3 영역 */}
+        <div className="mt-[120px] w-full max-w-[1200px] px-4 lg:px-0 flex flex-col gap-[36px]">
+          <p className="text-[24px] sm:text-[28px] font-bold leading-[36px] sm:leading-[42px] text-[var(--color-white)] text-center sm:text-left">
             생산성을 높이는 다양한 설정 ⚡
           </p>
 
           {/* Section3 카드들 */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-[33px]">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-[24px] md:gap-[33px] w-full justify-center">
             <Section3
               src="/images/landing3.png"
               alt="대시보드 설정 이미지"

--- a/src/components/landing/Section2.tsx
+++ b/src/components/landing/Section2.tsx
@@ -2,54 +2,56 @@ import Image from "next/image";
 
 export default function Section2() {
   return (
-    <section className="flex flex-col items-center w-full px-4 sm:gap-[80px] gap-[60px]">
-      {/* 카드 1 */}
-      <div className="w-full max-w-[1200px] h-[600px] bg-[var(--color-black2)] rounded-lg relative flex flex-col md:flex-row gap-[40px] overflow-hidden">
-        {/* 텍스트 왼쪽 */}
-        <div className="w-full md:w-1/2 flex flex-col justify-center px-[40px] text-center md:text-left z-10">
-          <p className="text-[16px] md:text-[22px] text-[var(--color-gray2)] mb-[40px] md:mb-[100px] md:mt-0 mt-[50px]">
-            Point 1
-          </p>
-          <div className="text-[32px] md:text-[48px] font-bold leading-[44px] md:leading-[64px] text-[var(--color-white)]">
-            <p>일의 우선순위를</p>
-            <p>관리하세요</p>
+    <section className="w-full flex flex-col items-center px-4">
+      <div className="w-full max-w-[1200px] flex flex-col gap-[60px] sm:gap-[80px]">
+        {/* 카드 1 */}
+        <div className="h-[600px] bg-[var(--color-black2)] rounded-lg relative flex flex-col md:flex-row gap-[40px] overflow-hidden">
+          {/* 왼쪽 텍스트 */}
+          <div className="w-full md:w-1/2 flex flex-col justify-center px-[40px] text-center md:text-left z-10">
+            <p className="text-[16px] md:text-[22px] text-[var(--color-gray2)] mb-[40px] md:mb-[100px] md:mt-0 mt-[50px]">
+              Point 1
+            </p>
+            <div className="text-[32px] md:text-[48px] font-bold leading-[44px] md:leading-[64px] text-[var(--color-white)]">
+              <p>일의 우선순위를</p>
+              <p>관리하세요</p>
+            </div>
+          </div>
+
+          {/* 오른쪽 이미지 */}
+          <div className="w-full md:w-1/2 h-full relative flex items-end justify-end">
+            <Image
+              src="/images/landing1.png"
+              alt="우선순위 관리 예시"
+              width={594}
+              height={497}
+              className="w-auto max-h-[480px] object-contain"
+            />
           </div>
         </div>
 
-        {/* 이미지 오른쪽 */}
-        <div className="w-full md:w-1/2 h-full relative flex items-end justify-end">
-          <Image
-            src="/images/landing1.png"
-            alt="우선순위 관리 예시"
-            width={594}
-            height={497}
-            className="w-auto max-h-[480px] object-contain"
-          />
-        </div>
-      </div>
-
-      {/* 카드 2 */}
-      <div className="w-full max-w-[1200px] h-[600px] bg-[var(--color-black2)] rounded-lg relative flex flex-col md:flex-row-reverse gap-[40px] overflow-hidden">
-        {/* 텍스트 */}
-        <div className="w-full md:w-1/2 flex flex-col justify-center px-[40px] text-center md:text-left z-10">
-          <p className="text-[14px] md:text-[16px] text-[var(--color-gray2)] mb-[40px] md:mb-[100px] md:mt-0 mt-[50px]">
-            Point 2
-          </p>
-          <div className="text-[32px] md:text-[48px] font-bold leading-[44px] md:leading-[64px] text-[var(--color-white)]">
-            <p>해야 할 일을</p>
-            <p>등록하세요</p>
+        {/* 카드 2 */}
+        <div className="h-[600px] bg-[var(--color-black2)] rounded-lg relative flex flex-col md:flex-row-reverse gap-[40px] overflow-hidden">
+          {/* 왼쪽 텍스트 */}
+          <div className="w-full md:w-1/2 flex flex-col justify-center px-[40px] text-center md:text-left z-10">
+            <p className="text-[14px] md:text-[16px] text-[var(--color-gray2)] mb-[40px] md:mb-[100px] md:mt-0 mt-[50px]">
+              Point 2
+            </p>
+            <div className="text-[32px] md:text-[48px] font-bold leading-[44px] md:leading-[64px] text-[var(--color-white)]">
+              <p>해야 할 일을</p>
+              <p>등록하세요</p>
+            </div>
           </div>
-        </div>
 
-        {/* 이미지 */}
-        <div className="w-full md:w-1/2 h-full relative flex items-end justify-end">
-          <Image
-            src="/images/landing2.png"
-            alt="할 일 등록 예시"
-            width={436}
-            height={502}
-            className="w-auto max-h-[480px] object-contain"
-          />
+          {/* 오른쪽 이미지 */}
+          <div className="w-full md:w-1/2 h-full relative flex items-end justify-end">
+            <Image
+              src="/images/landing2.png"
+              alt="할 일 등록 예시"
+              width={436}
+              height={502}
+              className="w-auto max-h-[480px] object-contain"
+            />
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/landing/Section3.tsx
+++ b/src/components/landing/Section3.tsx
@@ -25,7 +25,7 @@ export default function Section3({
   });
 
   return (
-    <div className="col-span-1 w-full max-w-[378px] grid rounded-lg overflow-hidden shadow-sm">
+    <div className="w-full max-w-[320px] sm:max-w-[360px] md:max-w-[360px] lg:max-w-[378px] mx-auto grid rounded-lg overflow-hidden shadow-sm">
       {/* 상단 이미지 영역 */}
       <div
         className={clsx(


### PR DESCRIPTION
## 작업 내용

- 랜딩페이지 하단부 그리드와 중간의 section2의 박스 정렬을 수정하였습니다.
- ![image](https://github.com/user-attachments/assets/81b65b80-9201-40ec-b9df-3e953d1ea5cf)
- ![image](https://github.com/user-attachments/assets/6a5ee86a-9cce-4d55-8521-aec6e0b6b912)
- ![image](https://github.com/user-attachments/assets/e065cbf6-3bb9-4e6d-8a59-67963985f295)

