### PR TITLE
[Style, Refactor] edit: 내부 컴포넌트 정렬 통일 / NewDashboard: 대시보드 이름 30자 제한 / InviteRecords: 초대 내역 즉시 반영

### DIFF
--- a/src/components/modal/ChangeBebridge.tsx
+++ b/src/components/modal/ChangeBebridge.tsx
@@ -89,18 +89,21 @@ const ChangeBebridge = ({ onUpdate }: ChangeBebridgeProps) => {
   return (
     <div className="min-h-[312px] lg:w-[620px] sm:w-[544px] w-[284px] bg-white rounded-[12px] p-[24px] flex flex-col">
       <div className="w-full flex justify-center">
-        <div className="flex flex-col w-[252px] md:w-[488px] lg:w-[564px]">
-          <h2 className="text-left text-black3 text-[20px] sm:text-[24px] font-bold">
+        {/* 내부 아이템 컨테이너 */}
+        <div className="flex flex-col lg:w-[564px] md:w-[488px] w-[252px]">
+          {/* 헤더 */}
+          <h2 className="text-left text-black3 font-bold sm:text-[24px] text-[20px]">
             {dashboardDetail.title}
           </h2>
 
+          {/* 변경할 제목 입력창 */}
           <div className="relative w-full mt-6">
             <Input
               type="text"
               onChange={handleTitleChange}
               value={title}
               label="대시보드 이름"
-              labelClassName="text-left text-black3 text-[16px] sm:text-[18px] font-medium mb-1"
+              labelClassName="text-left text-black3 font-medium sm:text-[18px] text-[16px] mb-1"
               placeholder="변경할 이름을 입력해 주세요"
               className="max-w-none mb-1 pr-[52px] placeholder:text-[14px] placeholder:sm:text-[16px]"
             />
@@ -109,6 +112,7 @@ const ChangeBebridge = ({ onUpdate }: ChangeBebridgeProps) => {
             </span>
           </div>
 
+          {/* 컬러칩 선택 */}
           <div className="flex mt-3">
             {colors.map((color, index) => (
               <div key={index} className="relative">
@@ -130,6 +134,8 @@ const ChangeBebridge = ({ onUpdate }: ChangeBebridgeProps) => {
               </div>
             ))}
           </div>
+
+          {/* 변경 버튼 */}
           <div className="flex mt-6">
             <button
               onClick={handleSubmit}

--- a/src/components/modal/ChangeBebridge.tsx
+++ b/src/components/modal/ChangeBebridge.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, ChangeEvent } from "react";
 import { useRouter } from "next/router";
 import Input from "../input/Input";
 import Image from "next/image";
@@ -18,8 +18,10 @@ const ChangeBebridge = ({ onUpdate }: ChangeBebridgeProps) => {
     {}
   );
   const [title, setTitle] = useState("");
+  const [titleLength, setTitleLength] = useState<number>(0);
   const [selected, setSelected] = useState<number | null>(null);
   const colors = ["#7ac555", "#760DDE", "#FF9800", "#76A5EA", "#E876EA"];
+  const maxTitleLength = 30;
 
   /* 대시보드 이름 데이터 */
   useEffect(() => {
@@ -40,6 +42,7 @@ const ChangeBebridge = ({ onUpdate }: ChangeBebridgeProps) => {
         }
       } catch (error) {
         console.error("대시보드 상세내용 불러오는데 오류 발생:", error);
+        toast.error("대시보드를 불러오는 데 실패했습니다.");
       }
     };
     if (dashboardId) {
@@ -48,10 +51,17 @@ const ChangeBebridge = ({ onUpdate }: ChangeBebridgeProps) => {
   }, [dashboardId]);
 
   /* 대시보드 이름 변경 버튼 */
-  const handleUpdate = async () => {
-    const dashboardIdNumber = Number(dashboardId);
+  const handleTitleChange = async (value: string) => {
+    if (value.length <= maxTitleLength) {
+      setTitle(value);
+      setTitleLength(value.length);
+    }
+  };
+
+  const handleSubmit = async () => {
     if (!dashboardId || selected === null) return;
 
+    const dashboardIdNumber = Number(dashboardId);
     const payload = {
       title,
       color: colors[selected],
@@ -77,48 +87,62 @@ const ChangeBebridge = ({ onUpdate }: ChangeBebridgeProps) => {
   };
 
   return (
-    <div className="lg:w-[620px] lg:h-[344px] sm:w-[544px] sm:h-[344px] w-[284px] h-[312px] bg-white rounded-[12px] p-[24px] flex flex-col">
-      <h2 className="text-black3 text-[20px] sm:text-[24px] font-bold">
-        {dashboardDetail.title}
-      </h2>
-      <Input
-        type="text"
-        onChange={setTitle}
-        label="대시보드 이름"
-        labelClassName="text-black3 text-[16px] sm:text-[18px] font-medium mt-6"
-        placeholder="뉴프로젝트"
-        className="max-w-[620px] mb-1"
-      />
+    <div className="min-h-[312px] lg:w-[620px] sm:w-[544px] w-[284px] bg-white rounded-[12px] p-[24px] flex flex-col">
+      <div className="w-full flex justify-center">
+        <div className="flex flex-col w-[252px] md:w-[488px] lg:w-[564px]">
+          <h2 className="text-left text-black3 text-[20px] sm:text-[24px] font-bold">
+            {dashboardDetail.title}
+          </h2>
 
-      <div className="flex mt-3">
-        {colors.map((color, index) => (
-          <div key={index} className="relative">
-            <button
-              className="cursor-pointer w-[30px] h-[30px] rounded-[15px] mr-2 transition-all duration-200 
-                    hover:opacity-70 hover:scale-110"
-              style={{ backgroundColor: color }}
-              onClick={() => setSelected(index)} // 색상 선택 시 selected 업데이트
+          <div className="relative w-full mt-6">
+            <Input
+              type="text"
+              onChange={handleTitleChange}
+              value={title}
+              label="대시보드 이름"
+              labelClassName="text-left text-black3 text-[16px] sm:text-[18px] font-medium mb-1"
+              placeholder="변경할 이름을 입력해 주세요"
+              className="max-w-none mb-1 pr-[52px] placeholder:text-[14px] placeholder:sm:text-[16px]"
             />
-            {selected === index && (
-              <Image
-                src="/svgs/check.svg"
-                alt="선택됨"
-                width={23}
-                height={23}
-                className="cursor-pointer absolute top-4 left-3.5 transform -translate-x-1/2 -translate-y-1/2"
-              />
-            )}
+            <span className="absolute right-3 bottom-1 top-4/6 -translate-y-2/6 font-light text-[12px] sm:text-[14px] text-[var(--color-gray1)] sm:pr-1.5">
+              {titleLength} / {maxTitleLength}
+            </span>
           </div>
-        ))}
-      </div>
-      <div className="mt-8 flex">
-        <button
-          onClick={handleUpdate}
-          disabled={selected === null} // color가 없으면 버튼 비활성화
-          className={`cursor-pointer sm:w-[572px] sm:h-[54px] w-[252px] h-[54px] rounded-[8px] border border-[var(--color-gray3)] bg-[var(--primary)] text-[var(--color-white)] ${selected === null ? "bg-gray-300 cursor-not-allowed" : "bg-[var(--primary)]"}`}
-        >
-          변경
-        </button>
+
+          <div className="flex mt-3">
+            {colors.map((color, index) => (
+              <div key={index} className="relative">
+                <button
+                  className="cursor-pointer w-[30px] h-[30px] rounded-[15px] mr-2 transition-all duration-200 
+                    hover:opacity-70 hover:scale-110"
+                  style={{ backgroundColor: color }}
+                  onClick={() => setSelected(index)} // 색상 선택 시 selected 업데이트
+                />
+                {selected === index && (
+                  <Image
+                    src="/svgs/check.svg"
+                    alt="선택됨"
+                    width={23}
+                    height={23}
+                    className="cursor-pointer absolute top-4 left-3.5 transform -translate-x-1/2 -translate-y-1/2"
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+          <div className="flex mt-6">
+            <button
+              onClick={handleSubmit}
+              disabled={selected === null} // color가 없으면 버튼 비활성화
+              className={`cursor-pointer w-full sm:h-[54px] h-[54px]
+            rounded-[8px] border border-[var(--color-gray3)] bg-[var(--primary)]
+            text-[var(--color-white)] font-semibold text-[14px] sm:text-[16px]
+            ${selected === null ? "bg-gray-300 cursor-not-allowed" : "bg-[var(--primary)]"}`}
+            >
+              변경
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/modal/ChangeBebridge.tsx
+++ b/src/components/modal/ChangeBebridge.tsx
@@ -50,7 +50,7 @@ const ChangeBebridge = ({ onUpdate }: ChangeBebridgeProps) => {
     }
   }, [dashboardId]);
 
-  /* 대시보드 이름 변경 버튼 */
+  /* 대시보드 이름 글자수 제한 */
   const handleTitleChange = async (value: string) => {
     if (value.length <= maxTitleLength) {
       setTitle(value);
@@ -78,7 +78,7 @@ const ChangeBebridge = ({ onUpdate }: ChangeBebridgeProps) => {
         color: colors[selected],
       }));
 
-      toast.success("대시보드가 변경되었습니다!");
+      toast.success("대시보드가 변경되었습니다.");
       if (onUpdate) onUpdate();
     } catch (error) {
       console.error("대시보드 변경 실패:", error);

--- a/src/components/modal/InviteDashboard.tsx
+++ b/src/components/modal/InviteDashboard.tsx
@@ -8,7 +8,13 @@ import { AxiosError } from "axios";
 import { toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
-export default function InviteDashboard({ onClose }: { onClose?: () => void }) {
+export default function InviteDashboard({
+  onClose,
+  onUpdate,
+}: {
+  onClose?: () => void;
+  onUpdate?: () => void;
+}) {
   const [email, setEmail] = useState("");
   const router = useRouter();
   const { dashboardId } = router.query;
@@ -32,6 +38,9 @@ export default function InviteDashboard({ onClose }: { onClose?: () => void }) {
             },
           }
         );
+
+        if (onUpdate) onUpdate();
+
         if (res.data && Array.isArray(res.data.invitations)) {
           // 초대내역 리스트
           const inviteData = res.data.invitations.map(
@@ -67,6 +76,7 @@ export default function InviteDashboard({ onClose }: { onClose?: () => void }) {
       });
 
       toast.success("멤버 초대에 성공했습니다.");
+      onUpdate?.();
       onClose?.();
     } catch (error) {
       if (error instanceof AxiosError) {

--- a/src/components/modal/NewDashboard.tsx
+++ b/src/components/modal/NewDashboard.tsx
@@ -24,8 +24,18 @@ export default function NewDashboard({ onClose, onCreate }: NewDashboardProps) {
   const [title, setTitle] = useState("");
   const [selected, setSelected] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
+  const [titleLength, setTitleLength] = useState<number>(0);
 
+  const maxTitleLength = 30;
   const colors = ["#7ac555", "#760DDE", "#FF9800", "#76A5EA", "#E876EA"];
+
+  /* 대시보드 이름 글자수 제한 */
+  const handleTitleChange = async (value: string) => {
+    if (value.length <= maxTitleLength) {
+      setTitle(value);
+      setTitleLength(value.length);
+    }
+  };
 
   const handleSubmit = async () => {
     const payload = {
@@ -38,6 +48,7 @@ export default function NewDashboard({ onClose, onCreate }: NewDashboardProps) {
       const response = await createDashboard(payload);
       onCreate?.(response.data);
       onClose?.();
+      toast.success("대시보드가 생성되었습니다.");
     } catch (error) {
       console.error("대시보드 생성 실패:", error);
       toast.error("대시보드 생성에 실패했습니다.");
@@ -50,14 +61,20 @@ export default function NewDashboard({ onClose, onCreate }: NewDashboardProps) {
     <div className="fixed inset-0 flex items-center justify-center bg-black/35 z-50">
       <div className="bg-white p-6 rounded-lg shadow-lg w-[327px] sm:w-[584px] sm:h-[344px]">
         <h2 className="text-sm sm:text-[24px] font-bold">새로운 대시보드</h2>
-        <Input
-          type="text"
-          onChange={setTitle}
-          label="대시보드 이름"
-          labelClassName="text-lg sm:text-base text-black3 mt-6"
-          placeholder="뉴프로젝트"
-          className="max-w-[620px] mb-1"
-        />
+        <div className="relative w-full">
+          <Input
+            type="text"
+            value={title}
+            onChange={handleTitleChange}
+            label="대시보드 이름"
+            labelClassName="text-lg sm:text-base text-black3 mt-6"
+            placeholder="뉴 프로젝트"
+            className="max-w-[620px] mb-1 sm:pr-0 pr-14"
+          />
+          <span className="absolute right-3 top-4/6 -translate-y-1/5 font-light text-[12px] sm:text-[14px] text-[var(--color-gray1)] sm:pr-1.5">
+            {titleLength} / {maxTitleLength}
+          </span>
+        </div>
 
         <div className="mt-3 flex relative">
           {colors.map((color, index) => (

--- a/src/components/modalInput/ModalInput.tsx
+++ b/src/components/modalInput/ModalInput.tsx
@@ -36,7 +36,7 @@ export default function ModalInput({
     defaultValue ? new Date(defaultValue) : null
   );
   const [titleLength, setTitleLength] = useState<number>(0);
-  const maxTitleLength = 70;
+  const maxTitleLength = 50;
 
   useEffect(() => {
     if (label === "태그" && defaultValueArray.length > 0) {

--- a/src/components/table/InviteRecords.tsx
+++ b/src/components/table/InviteRecords.tsx
@@ -133,7 +133,9 @@ const InviteRecords = ({ dashboardId }: { dashboardId: string }) => {
       </div>
 
       {/* 구성원 리스트 */}
-      <p className="sm:text-base text-sm text-gray-500 mt-6">이메일</p>
+      <p className="mt-6 text-[var(--color-gray2)] font-normal text-[14px] sm:text-[16px]">
+        이메일
+      </p>
       <ul>
         {paginatedInvitation.map((invite, index) => (
           <li

--- a/src/components/table/InviteRecords.tsx
+++ b/src/components/table/InviteRecords.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Pagination from "./TablePagination";
 import InviteDashboard from "../modal/InviteDashboard";
 import { apiRoutes } from "@/api/apiRoutes";
@@ -6,7 +6,12 @@ import axiosInstance from "@/api/axiosInstance";
 import { AxiosError } from "axios";
 import { toast } from "react-toastify";
 
-const InviteRecords = ({ dashboardId }: { dashboardId: string }) => {
+const InviteRecords = ({
+  dashboardId,
+}: {
+  dashboardId: string;
+  onUpdate?: () => void;
+}) => {
   const [inviteList, setInviteList] = useState<
     Array<{
       id: number;
@@ -15,33 +20,34 @@ const InviteRecords = ({ dashboardId }: { dashboardId: string }) => {
   >([]);
 
   /* 초대내역 목록 api 호출*/
-  useEffect(() => {
-    const fetchMembers = async () => {
-      try {
-        const dashboardIdNumber = Number(dashboardId);
-        const res = await axiosInstance.get(
-          apiRoutes.dashboardInvite(dashboardIdNumber),
-          {
-            params: {
-              dashboardId,
-            },
-          }
-        );
-        if (res.data && Array.isArray(res.data.invitations)) {
-          // 이메일 리스트를 객체 배열로 저장
-          const inviteData = res.data.invitations.map(
-            (item: { id: number; invitee: { email: string } }) => ({
-              id: item.id,
-              email: item.invitee.email,
-            })
-          );
-          setInviteList(inviteData);
-        }
-      } catch (error) {
-        console.error("초대내역 불러오는데 오류 발생:", error);
-      }
-    };
 
+  const fetchMembers = useCallback(async () => {
+    try {
+      const dashboardIdNumber = Number(dashboardId);
+      const res = await axiosInstance.get(
+        apiRoutes.dashboardInvite(dashboardIdNumber),
+        {
+          params: {
+            dashboardId,
+          },
+        }
+      );
+      if (res.data && Array.isArray(res.data.invitations)) {
+        // 이메일 리스트를 객체 배열로 저장
+        const inviteData = res.data.invitations.map(
+          (item: { id: number; invitee: { email: string } }) => ({
+            id: item.id,
+            email: item.invitee.email,
+          })
+        );
+        setInviteList(inviteData);
+      }
+    } catch (error) {
+      console.error("초대내역 불러오는데 오류 발생:", error);
+    }
+  }, [dashboardId]);
+
+  useEffect(() => {
     if (dashboardId) {
       fetchMembers();
     }
@@ -140,7 +146,10 @@ const InviteRecords = ({ dashboardId }: { dashboardId: string }) => {
                 초대하기
               </button>
               {isModalOpen && (
-                <InviteDashboard onClose={() => setIsModalOpen(false)} />
+                <InviteDashboard
+                  onClose={() => setIsModalOpen(false)}
+                  onUpdate={fetchMembers}
+                />
               )}
             </div>
           </div>

--- a/src/components/table/InviteRecords.tsx
+++ b/src/components/table/InviteRecords.tsx
@@ -101,64 +101,84 @@ const InviteRecords = ({ dashboardId }: { dashboardId: string }) => {
   };
 
   return (
-    <div className="lg:w-[620px] w-[284px] sm:w-[544px] min:h-[337px] sm:h-[430px] relative p-6 rounded-[12px] bg-white">
-      <div className="flex justify-between items-start sm:items-center">
-        {/* 제목 */}
-        <p className="text-black3 text-[20px] sm:text-[24px] font-bold">
-          초대 내역
-        </p>
+    <div
+      className="relative min-h-[312px] lg:w-[620px] sm:w-[544px] w-[284px]
+    bg-white rounded-[12px] p-[24px] flex flex-col"
+    >
+      <div className="w-full flex justify-center">
+        {/* 내부 아이템 컨테이너 */}
+        <div className="flex flex-col lg:w-[564px] md:w-[488px] w-[252px]">
+          {/* 헤더 */}
+          <div className="flex justify-between">
+            <p className="text-black3 font-bold sm:text-[24px] text-[20px]">
+              초대 내역
+            </p>
 
-        {/* 페이지네이션 + 초대하기 버튼 컨테이너 */}
-        <div className="flex flex-col sm:flex-row items-end sm:items-center gap-4">
-          {/* 페이지네이션 */}
-          <Pagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            onPrev={handlePrevPage}
-            onNext={handleNextPage}
-          />
+            {/* 페이지네이션 + 초대하기 버튼 컨테이너 */}
+            <div className="flex flex-col sm:flex-row items-end sm:items-center gap-3">
+              {/* 페이지네이션 */}
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPrev={handlePrevPage}
+                onNext={handleNextPage}
+              />
 
-          {/* 초대하기 버튼 (모바일에서 페이지네이션 아래로 이동) */}
-          <button
-            onClick={() => setIsModalOpen(true)}
-            className="cursor-pointer text-[12px] sm:text-[14px] sm:w-[105px] w-[86px] sm:h-[32px] h-[26px] rounded-[4px] bg-[#5534DA] text-white flex items-center justify-center gap-2"
-          >
-            <img src="/svgs/add_white_box.svg" alt="icon" className="w-4 h-4" />
-            초대하기
-          </button>
-          {isModalOpen && (
-            <InviteDashboard onClose={() => setIsModalOpen(false)} />
-          )}
+              {/* 초대하기 버튼 (모바일에서 페이지네이션 아래로 이동) */}
+              <button
+                onClick={() => setIsModalOpen(true)}
+                className="cursor-pointer sm:w-[105px] w-[86px] sm:h-[32px] h-[26px]
+                flex items-center justify-center gap-2
+                bg-[var(--primary)] rounded-[4px]
+                text-white font-normal sm:text-[14px] text-[12px]"
+              >
+                <img
+                  src="/svgs/add_white_box.svg"
+                  alt="icon"
+                  className="w-4 h-4"
+                />
+                초대하기
+              </button>
+              {isModalOpen && (
+                <InviteDashboard onClose={() => setIsModalOpen(false)} />
+              )}
+            </div>
+          </div>
+
+          {/* 구성원 리스트 */}
+          <p className="mt-6 text-[var(--color-gray2)] font-normal text-[14px] sm:text-[16px]">
+            이메일
+          </p>
+
+          <ul>
+            {paginatedInvitation.map((invite, index) => (
+              <li
+                key={index}
+                className={`flex items-center justify-between sm:mt-4 sm:pb-4 mt-3 pb-3 ${
+                  index !== paginatedInvitation.length - 1
+                    ? "border-b border-gray-200"
+                    : ""
+                }`}
+              >
+                <div className="flex items-center">
+                  <p className="text-black3 font-normal sm:text-[16px] text-[14px]">
+                    {invite.email}
+                  </p>{" "}
+                  {/* 이메일 출력 */}
+                </div>
+                <button
+                  onClick={() => handleCancel(invite.id)}
+                  className="cursor-pointer px-2 py-1 h-[32px] sm:h-[32px] w-[52px] sm:w-[84px] md:w-[84px]
+                  border border-[var(--color-gray3)] text-[var(--primary)] rounded-md hover:bg-gray-100
+                  font-normal sm:text-[14px] text-[12px]"
+                >
+                  취소
+                </button>
+              </li>
+            ))}
+          </ul>
         </div>
       </div>
-
-      {/* 구성원 리스트 */}
-      <p className="mt-6 text-[var(--color-gray2)] font-normal text-[14px] sm:text-[16px]">
-        이메일
-      </p>
-      <ul>
-        {paginatedInvitation.map((invite, index) => (
-          <li
-            key={index}
-            className={`flex items-center justify-between mt-3 pb-4 ${
-              index !== paginatedInvitation.length - 1
-                ? "border-b border-gray-200"
-                : ""
-            }`}
-          >
-            <div className="flex items-center gap-4">
-              <p className="sm:text-base text-sm">{invite.email}</p>{" "}
-              {/* 이메일 출력 */}
-            </div>
-            <button
-              onClick={() => handleCancel(invite.id)}
-              className="text-12m cursor-pointer sm:font-sm h-[32px] sm:h-[32px] w-[52px] sm:w-[84px] md:w-[84px] border border-[var(--color-gray3)] text-[var(--primary)] px-2 py-1 rounded-md hover:bg-gray-100"
-            >
-              취소
-            </button>
-          </li>
-        ))}
-      </ul>
     </div>
   );
 };

--- a/src/components/table/TablePagination.tsx
+++ b/src/components/table/TablePagination.tsx
@@ -26,7 +26,7 @@ const Pagination: React.FC<PaginationProps> = ({
           onClick={onPrev}
           disabled={currentPage === 1}
           className={`w-9 sm:w-10 h-9 sm:h-10 flex justify-center items-center border-r border-gray-300
-            ${currentPage === 1 ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:bg-gray-100"}`}
+            ${currentPage === 1 ? "opacity-50 cursor-default" : "cursor-pointer hover:bg-gray-100"}`}
         >
           <img
             src="/svgs/arrow_backward_white.svg"
@@ -38,8 +38,8 @@ const Pagination: React.FC<PaginationProps> = ({
         <button
           onClick={onNext}
           disabled={currentPage === totalPages}
-          className={`w-9 sm:w-10 h-9 sm:h-10 flex justify-center items-center hover:bg-gray-100 
-              ${currentPage === totalPages ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+          className={`w-9 sm:w-10 h-9 sm:h-10 flex justify-center items-center
+              ${currentPage === totalPages ? "opacity-50 cursor-default" : "cursor-pointer hover:bg-gray-100"}`}
         >
           <img
             src="/svgs/arrow_forward_white.svg"

--- a/src/components/table/TablePagination.tsx
+++ b/src/components/table/TablePagination.tsx
@@ -15,7 +15,10 @@ const Pagination: React.FC<PaginationProps> = ({
 }) => {
   return (
     <div className="flex items-center">
-      <p className="relative -translate-y-[10px] sm:text-xs text-sm text-gray-700 mt-4 text-center mr-3">
+      <p
+        className="relative -translate-y-[10px] text-center mt-4 mr-3
+      text-black3 font-normal sm:text-[14px] text-[12px]"
+      >
         {totalPages} 페이지 중 {currentPage}
       </p>
       <div className="flex items-center border border-gray-300 rounded-lg overflow-hidden">

--- a/src/components/table/member/MemberList.tsx
+++ b/src/components/table/member/MemberList.tsx
@@ -57,77 +57,92 @@ const MemberList: React.FC<HeaderBebridgeProps> = ({ dashboardId }) => {
   }, [dashboardId]);
 
   return (
-    <div className="lg:w-[620px] lg:h-[404px] w-[284px] min:h-[337px] sm:w-[544px] sm:h-[404px] relative p-6 rounded-[12px] bg-white">
-      <div className="flex justify-between items-center">
-        <p className="text-black3 text-[20px] sm:text-[24px] font-bold">
-          구성원
-        </p>
-        <Pagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPrev={handlePrevPage}
-          onNext={handleNextPage}
-        />
-      </div>
+    <div className="min-h-[312px] lg:w-[620px] sm:w-[544px] w-[284px] bg-white rounded-[12px] p-[24px] flex flex-col">
+      <div className="w-full flex justify-center">
+        {/* 내부 아이템 컨테이너 */}
+        <div className="flex flex-col lg:w-[564px] md:w-[488px] w-[252px]">
+          {/* 헤더 */}
+          <div className="flex justify-between">
+            <p className="text-left text-black3 text-[20px] sm:text-[24px] font-bold">
+              구성원
+            </p>
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPrev={handlePrevPage}
+              onNext={handleNextPage}
+            />
+          </div>
 
-      {/* 구성원 리스트 */}
-      <p className="text-sm sm:text-base text-gray-500 mt-6 mb-4">이름</p>
+          {/* 구성원 리스트 */}
+          <div className="w-full mt-6">
+            <p className="mt-6 mb-4 text-[var(--color-gray2)] font-normal text-[14px] sm:text-[16px]">
+              이름
+            </p>
 
-      <ul>
-        {paginatedMembers.map((member, index) => (
-          <li
-            key={index}
-            className={`flex items-center justify-between mt-3 pb-4 ${
-              index !== paginatedMembers.length - 1
-                ? "border-b border-gray-200"
-                : ""
-            }`}
-          >
-            <div className="flex items-center gap-4">
-              {member.profileImageUrl ? (
-                <div className="relative w-[34px] h-[34px] md:w-[38px] md:h-[38px] rounded-full border-[2px] border-white overflow-hidden">
-                  <Image
-                    src={member.profileImageUrl}
-                    alt={member.nickname}
-                    fill
-                    className="object-cover"
-                  />
-                </div>
-              ) : (
-                <RandomProfile name={member.nickname} index={index} />
-              )}
-
-              <p className="text-sm sm:text-base">
-                {member.nickname}
-                {member.isOwner && "(소유자)"}
-              </p>
-            </div>
-
-            {!member.isOwner && (
-              <>
-                <button
-                  onClick={() => {
-                    setSelectedMemberId(member.id);
-                    setIsModalOpen(true);
-                  }}
-                  className="text-12m cursor-pointer sm:font-sm h-[32px] sm:h-[32px] w-[52px] sm:w-[84px] md:w-[84px] border border-[var(--color-gray3)] text-[var(--primary)] px-2 py-1 rounded-md hover:bg-gray-100"
+            <ul>
+              {paginatedMembers.map((member, index) => (
+                <li
+                  key={index}
+                  className={`flex items-center justify-between mt-3 pb-4 ${
+                    index !== paginatedMembers.length - 1
+                      ? "border-b border-gray-200"
+                      : ""
+                  }`}
                 >
-                  삭제
-                </button>
+                  <div className="flex items-center gap-3">
+                    {member.profileImageUrl ? (
+                      <div
+                        className="relative w-[34px] h-[34px] md:w-[38px] md:h-[38px]
+                      rounded-full border-[2px] border-white overflow-hidden"
+                      >
+                        <Image
+                          src={member.profileImageUrl}
+                          alt={member.nickname}
+                          fill
+                          className="object-cover"
+                        />
+                      </div>
+                    ) : (
+                      <RandomProfile name={member.nickname} index={index} />
+                    )}
 
-                {isModalOpen && selectedMemberId !== null && (
-                  <DelteMemberModal
-                    isOpen={isModalOpen}
-                    onClose={closeModal}
-                    id={selectedMemberId}
-                    memberDelete={fetchMembers}
-                  />
-                )}
-              </>
-            )}
-          </li>
-        ))}
-      </ul>
+                    <p className="text-black3 font-normal sm:text-[16px] text-[14px]">
+                      {member.nickname}
+                      {member.isOwner && "(소유자)"}
+                    </p>
+                  </div>
+
+                  {!member.isOwner && (
+                    <>
+                      <button
+                        onClick={() => {
+                          setSelectedMemberId(member.id);
+                          setIsModalOpen(true);
+                        }}
+                        className="cursor-pointer px-2 py-1 h-[32px] sm:h-[32px] w-[52px] sm:w-[84px] md:w-[84px]
+                        border border-[var(--color-gray3)] text-[var(--primary)] rounded-md hover:bg-gray-100
+                        font-normal sm:text-[14px] text-[12px]"
+                      >
+                        삭제
+                      </button>
+
+                      {isModalOpen && selectedMemberId !== null && (
+                        <DelteMemberModal
+                          isOpen={isModalOpen}
+                          onClose={closeModal}
+                          id={selectedMemberId}
+                          memberDelete={fetchMembers}
+                        />
+                      )}
+                    </>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/table/member/MemberList.tsx
+++ b/src/components/table/member/MemberList.tsx
@@ -84,7 +84,7 @@ const MemberList: React.FC<HeaderBebridgeProps> = ({ dashboardId }) => {
               {paginatedMembers.map((member, index) => (
                 <li
                   key={index}
-                  className={`flex items-center justify-between mt-3 pb-4 ${
+                  className={`sm:mt-4 sm:pb-4 mt-3 pb-3 flex items-center justify-between ${
                     index !== paginatedMembers.length - 1
                       ? "border-b border-gray-200"
                       : ""

--- a/src/components/table/member/RandomProfile.tsx
+++ b/src/components/table/member/RandomProfile.tsx
@@ -15,7 +15,7 @@ export default function RandomProfile({ name, index }: RandomProfileProps) {
 
   return (
     <div
-      className={`flex items-center justify-center text-white font-16sb rounded-full ${bgColor} w-[34px] h-[34px] md:w-[38px] md:h-[38px]`}
+      className={`flex items-center justify-center text-white font-16sb leading-none rounded-full ${bgColor} w-[34px] h-[34px] md:w-[38px] md:h-[38px]`}
     >
       {name[0]}
     </div>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
+import Image from "next/image";
 import useUserStore from "@/store/useUserStore";
 import { getUserInfo } from "@/api/users";
 import { postAuthData } from "@/api/auth";
@@ -44,18 +45,23 @@ export default function LoginPage() {
 
   return (
     <div className="flex flex-col items-center justify-center h-screen bg-white py-10">
-      <div className="text-center mb-[40px]">
-        <img
+      <div className="flex flex-col items-center justify-center mb-[30px]">
+        <Image
           src="/svgs/main-logo.svg"
           alt="태스키파이 로고 이미지"
-          className="w-[180px]"
+          width={120}
+          height={120}
+          className="object-contain sm:w-[180px]"
         />
-        <p className="font-20m text-black3">오늘도 만나서 반가워요!</p>
+        <p className="text-black3 font-midium text-[18px] sm:text-[20px]">
+          오늘도 만나서 반가워요!
+        </p>
       </div>
 
       <form
         onSubmit={handleSubmit}
-        className="flex flex-col w-[350px] md:w-[520px] gap-[20px] font-16r text-black3"
+        className="flex flex-col w-[350px] md:w-[520px] gap-[12px] sm:gap-[18px]
+        font-16r text-black3"
       >
         <Input
           type="email"
@@ -81,7 +87,7 @@ export default function LoginPage() {
         <button
           type="submit"
           disabled={!isFormValid}
-          className={`w-full h-[50px] rounded-[8px] text-white font-18m transition ${
+          className={`w-full h-[50px] rounded-[8px] text-white font-18m transition mt-1 ${
             isFormValid
               ? "bg-[var(--primary)] cursor-pointer hover:opacity-90}"
               : "bg-[var(--color-gray2)] cursor-not-allowed"

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
+import Image from "next/image";
 import { signUp } from "@/api/users";
 import Input from "@/components/input/Input";
 import Link from "next/link";
@@ -60,18 +61,22 @@ export default function SignUpPage() {
     items-center justify-center
     bg-white py-10"
     >
-      <div className="text-center mb-[25px]">
-        <img
+      <div className="flex flex-col items-center justify-center mb-[30px]">
+        <Image
           src="/svgs/main-logo.svg"
           alt="태스키파이 로고 이미지"
-          className="w-[180px] relative"
+          width={120}
+          height={120}
+          className="object-contain sm:w-[180px]"
         />
-        <p className="font-20m text-black3">첫 방문을 환영합니다!</p>
+        <p className="text-black3 font-midium text-[18px] sm:text-[20px]">
+          첫 방문을 환영합니다!
+        </p>
       </div>
 
       <form
         onSubmit={handleSubmit}
-        className="flex flex-col w-[350px] md:w-[520px] gap-[18px]
+        className="flex flex-col w-[350px] md:w-[520px] gap-[12px] sm:gap-[18px]
         font-16r text-black3"
       >
         <Input
@@ -135,7 +140,7 @@ export default function SignUpPage() {
         <button
           type="submit"
           disabled={!isFormValid}
-          className={`w-full h-[50px] rounded-[8px] text-white font-18m transition ${
+          className={`w-full h-[50px] rounded-[8px] text-white font-18m transition mt-1 ${
             isFormValid
               ? "bg-[var(--primary)] cursor-pointer hover:opacity-90}"
               : "bg-[var(--color-gray2)] cursor-not-allowed"


### PR DESCRIPTION
## 작업 내용
1. signup, login: 로고 이미지 크기 반응형 조정(모바일 사용성 향상)
2. edit_ChangeBebridge, MemberList, InviteRecords: 내부 컨테이너 생성해 아이템 정렬 통일
3. ChangeBebridge, NewDashboard: 대시보드 이름 30자 제한 적용
4. InviteRecords: 초대 내역 즉시 반영
5. edit_Pagination: 버튼 비활성화 시 cursor-defalt 변경, toggle 효과 삭제