### PR TITLE
[Style, Refactor] CardDetailModal: 전체적인 CSS 수정과 반응형 작업 / edit: 프로필 이미지 없이도 닉네임 변경

### DIFF
--- a/src/components/card/Profile.tsx
+++ b/src/components/card/Profile.tsx
@@ -52,12 +52,22 @@ export const ProfileCard = () => {
   };
 
   const handleSave = async () => {
-    if (!nickname || !image) return;
+    if (!nickname) return;
 
     try {
-      await updateProfile({ nickname, profileImageUrl: image });
+      const payload: { nickname: string; profileImageUrl?: string } = {
+        nickname,
+      };
+      if (image) {
+        payload.profileImageUrl = image;
+      }
+
+      await updateProfile(payload);
       updateNickname(nickname);
-      updateProfileImage(image);
+
+      if (image) {
+        updateProfileImage(image);
+      }
       toast.success("프로필 변경이 완료되었습니다.");
     } catch (error) {
       console.error("프로필 변경 실패:", error);

--- a/src/components/modal/ChangeBebridge.tsx
+++ b/src/components/modal/ChangeBebridge.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, ChangeEvent } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import Input from "../input/Input";
 import Image from "next/image";

--- a/src/components/modalDashboard/CardDetail.tsx
+++ b/src/components/modalDashboard/CardDetail.tsx
@@ -13,13 +13,13 @@ interface CardDetailProps {
 export default function CardDetail({ card, columnName }: CardDetailProps) {
   return (
     <div className="flex flex-col gap-5 w-full">
-      <div className="flex items-center gap-5">
+      <div className="flex flex-wrap items-center gap-5">
         {/* 칼럼 이름 태그 */}
         <ColumnNameTag label={columnName} />
         {/* 구분선 */}
         <div className="w-[1px] h-[20px] bg-[var(--color-gray3)]" />
         {/* 카드 태그 */}
-        <div className="flex gap-[6px]">
+        <div className="flex flex-wrap gap-[6px]">
           {card.tags.map((tag, idx) => {
             const { textColor, bgColor } = getTagColor(idx);
             return (

--- a/src/components/modalDashboard/CardDetail.tsx
+++ b/src/components/modalDashboard/CardDetail.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { CardDetailType } from "@/types/cards";
-import { ProfileIcon } from "./profelicon";
+import { ColumnNameTag } from "../modalInput/chips/ColumnNameTag";
 import ColorTagChip, {
   getTagColor,
 } from "@/components/modalInput/chips/ColorTagChip";
@@ -12,69 +12,33 @@ interface CardDetailProps {
 
 export default function CardDetail({ card, columnName }: CardDetailProps) {
   return (
-    <div className="p-4">
-      {/* 담당자 정보 박스 */}
-      <div className="absolute w-[181px] h-[155px] lg:[200px] top-20 right-10 rounded-lg p-3.5 bg-white border border-[#D9D9D9]">
-        <div className="mb-3">
-          <p className="text-sm font-semibold text-black3 mb-1">담당자</p>
-          <div className="flex items-center gap-2">
-            <ProfileIcon
-              userId={card.assignee.id}
-              nickname={card.assignee.nickname}
-              profileImageUrl={card.assignee.profileImageUrl ?? ""}
-              id={card.assignee.id}
-              imgClassName="w-6 h-6"
-              fontClassName="text-sm"
-            />
-            <span className="text-sm text-black3">
-              {card.assignee.nickname}
-            </span>
-          </div>
-
-          <div>
-            <p className="text-sm font-semibold text-black3 mb-1 mt-3">
-              마감일
-            </p>
-            <p className="text-sm text-black3">
-              {new Date(card.dueDate).toLocaleString("ko-KR", {
-                year: "numeric",
-                month: "2-digit",
-                day: "2-digit",
-                hour: "2-digit",
-                minute: "2-digit",
-              })}
-            </p>
-          </div>
+    <div className="flex flex-col gap-5 w-full">
+      <div className="flex items-center gap-5">
+        {/* 칼럼 이름 태그 */}
+        <ColumnNameTag label={columnName} />
+        {/* 구분선 */}
+        <div className="w-[1px] h-[20px] bg-[var(--color-gray3)]" />
+        {/* 카드 태그 */}
+        <div className="flex gap-[6px]">
+          {card.tags.map((tag, idx) => {
+            const { textColor, bgColor } = getTagColor(idx);
+            return (
+              <ColorTagChip key={idx} className={`${textColor} ${bgColor}`}>
+                {tag}
+              </ColorTagChip>
+            );
+          })}
         </div>
       </div>
 
-      {/* 상태 + 태그 */}
-      <div className="flex items-center gap-2 mb-2">
-        <span
-          className="rounded-full bg-violet-200 px-3 py-1 text-sm text-violet-800"
-          title={`상태: ${columnName}`}
-        >
-          {columnName}
-        </span>
-        <span className="text-2xl font-extralight text-[#D9D9D9]">|</span>
-        {card.tags.map((tag, idx) => {
-          const { textColor, bgColor } = getTagColor(idx);
-          return (
-            <ColorTagChip key={idx} className={`${textColor} ${bgColor}`}>
-              {tag}
-            </ColorTagChip>
-          );
-        })}
-      </div>
-
-      {/* 설명 */}
+      {/* 내용 */}
       <p
         className="
-          text-black3 p-2 overflow-auto
-          w-full max-w-[470px] md:max-w-[349px]
+          text-black font-normal sm:text-[14px] text-[12px] overflow-auto pr-1
+          w-full lg:max-w-[445px] sm:max-w-[420px] max-w-[295px]
+          min-h-0 sm:max-h-[100px] max-h-[80px]
           whitespace-pre-wrap word-break break-words
-          h-[70px]
-        "
+          "
       >
         {card.description}
       </p>
@@ -85,9 +49,10 @@ export default function CardDetail({ card, columnName }: CardDetailProps) {
           <Image
             src={card.imageUrl}
             alt="카드 이미지"
-            width={420}
-            height={226}
-            className="rounded-lg object-cover lg:w-[445px] lg:h-[260px] w-[420px] h-[246px]"
+            width={290}
+            height={168}
+            className="rounded-lg object-cover
+            lg:w-[445px] md:w-[420px]"
           />
         </div>
       )}

--- a/src/components/modalDashboard/CardDetailModal.tsx
+++ b/src/components/modalDashboard/CardDetailModal.tsx
@@ -101,10 +101,13 @@ export default function CardDetailPage({
         className="fixed inset-0 bg-black/30 z-50
       flex items-center justify-center px-4 sm:px-6"
       >
-        {/* 카드 컨테이너 */}
+        {/* 모달 컨테이너 */}
         <div
-          className="relative flex flex-col bg-white rounded-lg shadow-lg
-          lg:w-[730px] sm:w-[678px] w-[327px] min-h-[710px]"
+          className="relative flex flex-col
+          overflow-y-auto
+          max-w-[730px] max-h-[calc(100vh-4rem)]
+          lg:w-[730px] sm:w-[678px] w-[327px]
+          bg-white rounded-lg shadow-lg"
         >
           <div className="flex items-center justify-center px-6 pt-6 pb-2">
             {/* 내부 아이템 컨테이너 */}
@@ -123,16 +126,24 @@ export default function CardDetailPage({
                   {/* 메뉴 버튼 */}
                   <button
                     onClick={() => setShowMenu((prev) => !prev)}
-                    className="w-7 h-7 flex items-center justify-center hover:cursor-pointer"
+                    className="sm:w-[28px] sm:h-[28px] w-[20px] h-[20px]
+                    flex items-center justify-center hover:cursor-pointer"
                     title="수정하기"
                     type="button"
                   >
                     <MoreVertical className="w-8 h-8 text-black3 cursor-pointer" />
                   </button>
                   {showMenu && (
-                    <div className="absolute right-0 top-10 p-2 w-27 bg-white border border-[#D9D9D9] z-40 rounded-lg">
+                    <div
+                      className="absolute right-0 top-9.5 p-2 z-40
+                    sm:w-28 w-20
+                    bg-white border border-[#D9D9D9] rounded-lg"
+                    >
                       <button
-                        className="block w-full px-4 py-2 text-base text-gray-800 hover:bg-[#F1EFFD] hover:text-[#5534DA] rounded-sm cursor-pointer"
+                        className="w-full rounded-sm
+                        font-normal sm:text-[14px] text-[12px] text-black3
+                        hover:bg-[#F1EFFD] hover:text-[#5534DA]
+                        cursor-pointer"
                         type="button"
                         onClick={() => {
                           setIsEditModalOpen(true);
@@ -142,7 +153,10 @@ export default function CardDetailPage({
                         수정하기
                       </button>
                       <button
-                        className="block w-full px-4 py-2 text-base text-gray-800 hover:bg-[#F1EFFD] hover:text-[#5534DA] rounded-sm cursor-pointer"
+                        className="w-full rounded-sm
+                        font-normal sm:text-[14px] text-[12px] text-black3
+                        hover:bg-[#F1EFFD] hover:text-[#5534DA]
+                        cursor-pointer"
                         type="button"
                         onClick={() => deleteCardMutate()}
                       >
@@ -152,20 +166,24 @@ export default function CardDetailPage({
                   )}
                   {/* 닫기 버튼 */}
                   <button onClick={handleClose} title="닫기">
-                    <X className="w-7 h-7 flex items-center justify-center hover:cursor-pointer" />
+                    <X
+                      className="sm:w-[28px] sm:h-[28px] w-[20px] h-[20px]
+                    flex items-center justify-center hover:cursor-pointer"
+                    />
                   </button>
                 </div>
               </div>
 
-              {/* 카드 내용 */}
-              <div className="relative flex w-full">
+              {/* 카드 내용 + 담당자 컨테이너 */}
+              <div className="flex flex-col-reverse sm:flex-row gap-4">
                 <CardDetail card={cardData} columnName={columnName} />
-                <div className="absolute right-0">
+                <div>
                   <Representative card={card} />
                 </div>
               </div>
+
               {/* 댓글 입력창 */}
-              <div className="w-full lg:max-w-[445px] md:max-w-[420px] mt-4">
+              <div className="mt-4 w-full lg:max-w-[445px] md:max-w-[420px]">
                 <p className="mb-1 text-black3 font-medium sm:text-[16px] text-[14px]">
                   댓글
                 </p>
@@ -181,8 +199,9 @@ export default function CardDetailPage({
 
               {/* 댓글 목록 (스크롤 가능) */}
               <div
-                className="w-full max-w-[450px] sm:max-h-[180px] max-h-[70px]
-              mt-2 overflow-y-auto"
+                className="w-full lg:max-w-[445px] md:max-w-[420px]
+                sm:max-h-[140px] max-h-[70px]
+                my-2 overflow-y-auto"
               >
                 <CommentList
                   cardId={card.id}

--- a/src/components/modalDashboard/CardDetailModal.tsx
+++ b/src/components/modalDashboard/CardDetailModal.tsx
@@ -180,7 +180,10 @@ export default function CardDetailPage({
               </div>
 
               {/* 댓글 목록 (스크롤 가능) */}
-              <div className="w-full max-w-[450px] text-base max-h-[180px] overflow-y-auto scrollbar-hidden">
+              <div
+                className="w-full max-w-[450px] sm:max-h-[180px] max-h-[70px]
+              mt-2 overflow-y-auto"
+              >
                 <CommentList
                   cardId={card.id}
                   currentUserId={currentUserId}

--- a/src/components/modalDashboard/CardDetailModal.tsx
+++ b/src/components/modalDashboard/CardDetailModal.tsx
@@ -3,6 +3,7 @@ import { MoreVertical, X } from "lucide-react";
 import CardDetail from "./CardDetail";
 import CommentList from "./CommentList";
 import CardInput from "@/components/modalInput/CardInput";
+import { Representative } from "@/components/modalDashboard/Representative";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createComment } from "@/api/comment";
 import { deleteCard, EditCard } from "@/api/card";
@@ -95,78 +96,97 @@ export default function CardDetailPage({
 
   return (
     <>
-      <div className="fixed inset-0 bg-black/30 z-50 flex items-center justify-center px-4 sm:px-6">
+      {/* 모달 고정 div */}
+      <div
+        className="fixed inset-0 bg-black/30 z-50
+      flex items-center justify-center px-4 sm:px-6"
+      >
+        {/* 카드 컨테이너 */}
         <div
-          className="
-      relative bg-white rounded-lg shadow-lg flex flex-col
-      w-[327px] h-[710px]
-      md:w-[678px] md:h-[766px]
-      lg:w-[730px] lg:h-[763px]
-    "
+          className="relative flex flex-col bg-white rounded-lg shadow-lg
+          lg:w-[730px] sm:w-[678px] w-[327px] min-h-[710px]"
         >
-          <div className="flex justify-between items-center px-6 pt-6 pb-2">
-            <h2 className="font-24sb">{cardData.title}</h2>
-            <div className="flex items-center gap-3 relative" ref={popupRef}>
-              <button
-                onClick={() => setShowMenu((prev) => !prev)}
-                className="w-7 h-7 flex items-center justify-center hover:cursor-pointer"
-                title="수정하기"
-                type="button"
-              >
-                <MoreVertical className="w-8 h-8 text-black cursor-pointer" />
-              </button>
-              {showMenu && (
-                <div className="absolute right-0 top-10 p-2 w-27 bg-white border border-[#D9D9D9] z-40 rounded-lg">
+          <div className="flex items-center justify-center px-6 pt-6 pb-2">
+            {/* 내부 아이템 컨테이너 */}
+            <div className="flex flex-col lg:w-[674px] sm:w-[614px] w-[295px]">
+              {/* 헤더 */}
+              <div className="flex justify-between sm:mb-4 mb-2">
+                {/* 카드 제목 */}
+                <h2 className="text-black3 font-bold sm:text-[24px] text-[20px]">
+                  {cardData.title}
+                </h2>
+                {/* 버튼 컨테이너 */}
+                <div
+                  className="relative flex items-center sm:gap-[24px] gap-[16px]"
+                  ref={popupRef}
+                >
+                  {/* 메뉴 버튼 */}
                   <button
-                    className="block w-full px-4 py-2 text-base text-gray-800 hover:bg-[#F1EFFD] hover:text-[#5534DA] rounded-sm cursor-pointer"
+                    onClick={() => setShowMenu((prev) => !prev)}
+                    className="w-7 h-7 flex items-center justify-center hover:cursor-pointer"
+                    title="수정하기"
                     type="button"
-                    onClick={() => {
-                      setIsEditModalOpen(true);
-                      setShowMenu(false);
-                    }}
                   >
-                    수정하기
+                    <MoreVertical className="w-8 h-8 text-black3 cursor-pointer" />
                   </button>
-                  <button
-                    className="block w-full px-4 py-2 text-base text-gray-800 hover:bg-[#F1EFFD] hover:text-[#5534DA] rounded-sm cursor-pointer"
-                    type="button"
-                    onClick={() => deleteCardMutate()}
-                  >
-                    삭제하기
+                  {showMenu && (
+                    <div className="absolute right-0 top-10 p-2 w-27 bg-white border border-[#D9D9D9] z-40 rounded-lg">
+                      <button
+                        className="block w-full px-4 py-2 text-base text-gray-800 hover:bg-[#F1EFFD] hover:text-[#5534DA] rounded-sm cursor-pointer"
+                        type="button"
+                        onClick={() => {
+                          setIsEditModalOpen(true);
+                          setShowMenu(false);
+                        }}
+                      >
+                        수정하기
+                      </button>
+                      <button
+                        className="block w-full px-4 py-2 text-base text-gray-800 hover:bg-[#F1EFFD] hover:text-[#5534DA] rounded-sm cursor-pointer"
+                        type="button"
+                        onClick={() => deleteCardMutate()}
+                      >
+                        삭제하기
+                      </button>
+                    </div>
+                  )}
+                  {/* 닫기 버튼 */}
+                  <button onClick={handleClose} title="닫기">
+                    <X className="w-7 h-7 flex items-center justify-center hover:cursor-pointer" />
                   </button>
                 </div>
-              )}
-              <button onClick={handleClose} title="닫기">
-                <X className="w-7 h-7 flex items-center justify-center hover:cursor-pointer" />
-              </button>
-            </div>
-          </div>
+              </div>
 
-          {/* 콘텐츠 (스크롤 없음) */}
-          <div className="px-6 pb-4 flex flex-col gap-6 flex-1 overflow-hidden">
-            {/* 카드 상세 */}
-            <CardDetail card={cardData} columnName={columnName} />
+              {/* 카드 내용 */}
+              <div className="relative flex w-full">
+                <CardDetail card={cardData} columnName={columnName} />
+                <div className="absolute right-0">
+                  <Representative card={card} />
+                </div>
+              </div>
+              {/* 댓글 입력창 */}
+              <div className="w-full lg:max-w-[445px] md:max-w-[420px] mt-4">
+                <p className="mb-1 text-black3 font-medium sm:text-[16px] text-[14px]">
+                  댓글
+                </p>
+                <CardInput
+                  hasButton
+                  small
+                  value={commentText}
+                  onTextChange={setCommentText}
+                  onButtonClick={handleCommentSubmit}
+                  placeholder="댓글 작성하기"
+                />
+              </div>
 
-            {/* 댓글 입력 */}
-            <div className="w-full max-w-[450px]">
-              <p className="text-sm font-semibold mb-2">댓글</p>
-              <CardInput
-                hasButton
-                small
-                value={commentText}
-                onTextChange={setCommentText}
-                onButtonClick={handleCommentSubmit}
-                placeholder="댓글 작성하기"
-              />
-            </div>
-
-            {/* 댓글 리스트 (스크롤 가능) */}
-            <div className="w-full max-w-[450px] text-base max-h-[180px] overflow-y-auto scrollbar-hidden">
-              <CommentList
-                cardId={card.id}
-                currentUserId={currentUserId}
-                teamId={""}
-              />
+              {/* 댓글 목록 (스크롤 가능) */}
+              <div className="w-full max-w-[450px] text-base max-h-[180px] overflow-y-auto scrollbar-hidden">
+                <CommentList
+                  cardId={card.id}
+                  currentUserId={currentUserId}
+                  teamId={""}
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/modalDashboard/CommentList.tsx
+++ b/src/components/modalDashboard/CommentList.tsx
@@ -37,16 +37,28 @@ export default function CommentList({
     data?.pages.flatMap((page) => page.comments) ?? [];
 
   return (
-    <div className="min-h-[80px] p-2 rounded bg-white shadow-sm">
-      {allComments.map((comment) => (
-        <div key={comment.id} className="p-2  last:border-b-0">
-          <UpdateComment
-            comment={comment}
-            currentUserId={currentUserId}
-            teamId={""}
-          />
-        </div>
-      ))}
+    <div
+      className="min-h-[80px] w-full rounded bg-white shadow-sm
+    flex flex-col overflow-y-scroll"
+    >
+      {allComments.length === 0 ? (
+        <p
+          className="sm:pt-8 pt-4 text-center text-[var(--color-gray1)]
+        font-normal sm:text-[14px] text-[12px]"
+        >
+          작성된 댓글이 없습니다.
+        </p>
+      ) : (
+        allComments.map((comment) => (
+          <div key={comment.id} className="py-2 last:border-b-0">
+            <UpdateComment
+              comment={comment}
+              currentUserId={currentUserId}
+              teamId={""}
+            />
+          </div>
+        ))
+      )}
       <div ref={ref} />
     </div>
   );

--- a/src/components/modalDashboard/CommentList.tsx
+++ b/src/components/modalDashboard/CommentList.tsx
@@ -38,8 +38,9 @@ export default function CommentList({
 
   return (
     <div
-      className="min-h-[80px] w-full rounded bg-white shadow-sm
-    flex flex-col overflow-y-scroll"
+      className="min-h-[80px] sm:max-h-[255px] max-h-[215px] w-full
+      rounded bg-white
+      flex flex-col"
     >
       {allComments.length === 0 ? (
         <p
@@ -50,7 +51,7 @@ export default function CommentList({
         </p>
       ) : (
         allComments.map((comment) => (
-          <div key={comment.id} className="py-2 last:border-b-0">
+          <div key={comment.id} className=" shrink-0 py-2 last:border-b-0">
             <UpdateComment
               comment={comment}
               currentUserId={currentUserId}

--- a/src/components/modalDashboard/CommentList.tsx
+++ b/src/components/modalDashboard/CommentList.tsx
@@ -38,7 +38,7 @@ export default function CommentList({
 
   return (
     <div
-      className="min-h-[80px] sm:max-h-[255px] max-h-[215px] w-full
+      className="min-h-[80px] sm:max-h-[240px] max-h-[215px] w-full
       rounded bg-white
       flex flex-col"
     >

--- a/src/components/modalDashboard/ProfileIcon.tsx
+++ b/src/components/modalDashboard/ProfileIcon.tsx
@@ -15,16 +15,17 @@ export const ProfileIcon: React.FC<ProfileIconProps> = ({
   nickname,
   profileImageUrl,
 }) => (
-  <div className="relative w-[34px] h-[34px] md:w-[38px] md:h-[38px] rounded-full overflow-hidden">
+  <>
     {profileImageUrl ? (
       <Image
         src={profileImageUrl}
         alt="유저 프로필 아이콘"
-        fill
-        className="object-cover"
+        width={34}
+        height={34}
+        className="object-cover w-[28px] h-[28px] rounded-full"
       />
     ) : (
       <RandomProfile name={nickname} />
     )}
-  </div>
+  </>
 );

--- a/src/components/modalDashboard/ProfileIcon.tsx
+++ b/src/components/modalDashboard/ProfileIcon.tsx
@@ -22,7 +22,7 @@ export const ProfileIcon: React.FC<ProfileIconProps> = ({
         alt="유저 프로필 아이콘"
         width={34}
         height={34}
-        className="object-cover w-[28px] h-[28px] rounded-full"
+        className="object-cover w-[26px] h-[26px] rounded-full"
       />
     ) : (
       <RandomProfile name={nickname} />

--- a/src/components/modalDashboard/Representative.tsx
+++ b/src/components/modalDashboard/Representative.tsx
@@ -1,4 +1,4 @@
-import { ProfileIcon } from "./profelicon";
+import { ProfileIcon } from "./ProfileIcon";
 import { CardDetailType } from "@/types/cards";
 
 interface RepresentativeProps {

--- a/src/components/modalDashboard/Representative.tsx
+++ b/src/components/modalDashboard/Representative.tsx
@@ -8,39 +8,44 @@ interface RepresentativeProps {
 export const Representative = ({ card }: RepresentativeProps) => {
   return (
     <div
-      className="flex flex-col gap-4 top-20 right-10 p-3.5 w-[181px] h-[155px] lg:[200px]
-    rounded-lg bg-white border border-[#D9D9D9]"
+      className="flex flex-col items-center justify-center gap-4
+      lg:w-[200px] sm:w-[180px] w-[290px]
+      sm:h-[155px] h-[65px]
+      rounded-lg bg-white border border-[#D9D9D9]"
     >
-      {/* 담당자 컨테이너 */}
-      <div className="">
-        <p className="font-12sb text-black3 mb-1">담당자</p>
-        <div className="flex items-center gap-2">
-          <ProfileIcon
-            userId={card.assignee.id}
-            nickname={card.assignee.nickname}
-            profileImageUrl={card.assignee.profileImageUrl ?? ""}
-            id={card.assignee.id}
-            imgClassName="w-6 h-6"
-            fontClassName="font-14r"
-          />
-          <span className="font-normal text-black3 sm:text-[14px] text-[12px]">
-            {card.assignee.nickname}
-          </span>
+      {/* 내부 아이템 컨테이너 */}
+      <div className="flex sm:flex-col sm:gap-4 gap-17">
+        {/* 담당자 컨테이너 */}
+        <div>
+          <p className="font-12sb text-black3 mb-1">담당자</p>
+          <div className="flex items-center gap-2">
+            <ProfileIcon
+              userId={card.assignee.id}
+              nickname={card.assignee.nickname}
+              profileImageUrl={card.assignee.profileImageUrl ?? ""}
+              id={card.assignee.id}
+              imgClassName="w-6 h-6"
+              fontClassName="font-14r"
+            />
+            <span className="font-normal text-black3 sm:text-[14px] text-[12px]">
+              {card.assignee.nickname}
+            </span>
+          </div>
         </div>
-      </div>
 
-      {/* 마감일 컨테이너 */}
-      <div>
-        <p className="font-12sb text-black3 mb-1">마감일</p>
-        <p className="font-normal text-black3 sm:text-[14px] text-[12px]">
-          {new Date(card.dueDate).toLocaleString("ko-KR", {
-            year: "numeric",
-            month: "2-digit",
-            day: "2-digit",
-            hour: "2-digit",
-            minute: "2-digit",
-          })}
-        </p>
+        {/* 마감일 컨테이너 */}
+        <div>
+          <p className="font-12sb text-black3 sm:mb-1 mb-[8px]">마감일</p>
+          <p className="font-normal text-black3 sm:text-[14px] text-[12px]">
+            {new Date(card.dueDate).toLocaleString("ko-KR", {
+              year: "numeric",
+              month: "2-digit",
+              day: "2-digit",
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/components/modalDashboard/Representative.tsx
+++ b/src/components/modalDashboard/Representative.tsx
@@ -1,0 +1,47 @@
+import { ProfileIcon } from "./profelicon";
+import { CardDetailType } from "@/types/cards";
+
+interface RepresentativeProps {
+  card: CardDetailType;
+}
+
+export const Representative = ({ card }: RepresentativeProps) => {
+  return (
+    <div
+      className="flex flex-col gap-4 top-20 right-10 p-3.5 w-[181px] h-[155px] lg:[200px]
+    rounded-lg bg-white border border-[#D9D9D9]"
+    >
+      {/* 담당자 컨테이너 */}
+      <div className="">
+        <p className="font-12sb text-black3 mb-1">담당자</p>
+        <div className="flex items-center gap-2">
+          <ProfileIcon
+            userId={card.assignee.id}
+            nickname={card.assignee.nickname}
+            profileImageUrl={card.assignee.profileImageUrl ?? ""}
+            id={card.assignee.id}
+            imgClassName="w-6 h-6"
+            fontClassName="font-14r"
+          />
+          <span className="font-normal text-black3 sm:text-[14px] text-[12px]">
+            {card.assignee.nickname}
+          </span>
+        </div>
+      </div>
+
+      {/* 마감일 컨테이너 */}
+      <div>
+        <p className="font-12sb text-black3 mb-1">마감일</p>
+        <p className="font-normal text-black3 sm:text-[14px] text-[12px]">
+          {new Date(card.dueDate).toLocaleString("ko-KR", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+          })}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/components/modalDashboard/UpdateComment.tsx
+++ b/src/components/modalDashboard/UpdateComment.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { deleteComment, updateComment } from "@/api/comment";
 import { Comment } from "@/types/comments";
-import { ProfileIcon } from "./profelicon";
+import { ProfileIcon } from "./ProfileIcon";
 import formatDate from "./formatDate";
 
 interface UpdateCommentProps {

--- a/src/components/modalDashboard/UpdateComment.tsx
+++ b/src/components/modalDashboard/UpdateComment.tsx
@@ -51,44 +51,68 @@ export default function UpdateComment({
         id={0}
       />
 
-      {/* 댓글 내용 */}
+      {/* 댓글 */}
       <div className="flex flex-col w-full space-y-1">
         {/* 작성자 + 시간 */}
-        <div className="flex items-center gap-2 text-sm text-gray-600">
-          <span className="font-semibold text-black">
+        <div
+          className="flex items-center gap-2
+        text-[var(--color-gray2)] font-normal sm:text-[12px] text-[10px]"
+        >
+          <span className="text-black3 font-semibold sm:text-[14px] text-[12px]">
             {comment.author.nickname}
           </span>
           <span>{formatDate(comment.createdAt)}</span>
         </div>
 
-        {/* 본문 */}
+        {/* 댓글 수정 입력창 */}
         {isEditing ? (
           <>
             <textarea
-              className="w-full p-2 text-sm"
+              className="w-full text-black3 font-normal sm:text-[14px] text-[12px]
+              outline-none"
               value={editedContent}
               onChange={(e) => setEditedContent(e.target.value)}
               aria-label="댓글"
             />
-            <div className="flex gap-2 mt-1 text-sm">
+            <div className="flex gap-2 text-black3 font-normal sm:text-[14px] text-[12px]">
               <button
                 onClick={handleSave}
                 disabled={editedContent === comment.content}
+                className="font-normal text-black3 sm:text-[12px] text-[10px]
+                cursor-pointer"
               >
                 저장
               </button>
-              <button onClick={handleEditToggle}>취소</button>
+              <button
+                onClick={handleEditToggle}
+                className="font-normal text-[var(--color-gray2)] sm:text-[12px] text-[10px]
+              cursor-pointer"
+              >
+                취소
+              </button>
             </div>
           </>
         ) : (
           <>
-            <p className="text-sm whitespace-pre-wrap break-words">
+            {/* 댓글 내용 */}
+            <p
+              className="whitespace-pre-wrap break-words
+            text-black3 font-normal sm:text-[14px] text-[12px]"
+            >
               {comment.content}
             </p>
+            {/* 버튼 컨테이너 */}
             {currentUserId === comment.author.id && (
-              <div className="flex gap-2 text-xs text-gray-500 mt-1">
-                <button onClick={handleEditToggle}>수정</button>
-                <button onClick={handleDelete}>삭제</button>
+              <div
+                className="flex gap-2 mt-1
+              text-[var(--color-gray2)] font-normal sm:text-[12px] text-[10px]"
+              >
+                <button onClick={handleEditToggle} className="cursor-pointer">
+                  수정
+                </button>
+                <button onClick={handleDelete} className="cursor-pointer">
+                  삭제
+                </button>
               </div>
             )}
           </>

--- a/src/components/modalInput/CardInput.tsx
+++ b/src/components/modalInput/CardInput.tsx
@@ -35,38 +35,38 @@ export default function CardInput({
         onChange={handleChange}
         placeholder={placeholder}
         className={clsx(
-          "p-4 w-full resize-none",
+          "sm:p-4 p-2 w-full resize-none",
+          "sm:h-[110px] h-[55px]",
           "bg-white rounded-md border border-[var(--color-gray3)]",
-          "text-black font-normal",
+          "text-black3 font-normal sm:text-[14px] text-[12px]",
           "focus:border-[var(--primary)] outline-none",
-          small ? "text-[12px]" : "text-[14px]",
           className
         )}
         style={{
-          height: small ? "110px" : "100px", // 고정된 높이 설정
           overflowY: "auto", // 내용이 넘치면 스크롤 생성
           wordWrap: "break-word",
           whiteSpace: "pre-wrap",
-          paddingBottom: hasButton ? "40px" : "8px", // 버튼과 겹치지 않도록 여백 추가
           boxSizing: "border-box", // padding과 border를 높이에 포함
         }}
       />
       {hasButton && (
-        <TextButton
-          disabled={value.trim().length === 0}
-          color="secondary"
-          buttonSize="xs"
-          onClick={onButtonClick}
-          className="absolute bottom-4 right-2.5 z-10 flex items-center justify-center
+        <div className="flex justify-end mt-[2px]">
+          <TextButton
+            disabled={value.trim().length === 0}
+            color="secondary"
+            buttonSize="xs"
+            onClick={onButtonClick}
+            className="bottom-4 right-2.5 z-10 flex items-center justify-center
           lg:w-[83px]
           md:w-[77px] md:h-[32px]
           w-[84px] h-[28px] rounded-sm
           border-[var(--color-gray3)] hover:bg-gray-100
           text-[var(--primary)] font-12m
           cursor-pointer whitespace-nowrap"
-        >
-          입력
-        </TextButton>
+          >
+            입력
+          </TextButton>
+        </div>
       )}
     </div>
   );

--- a/src/components/modalInput/CardInput.tsx
+++ b/src/components/modalInput/CardInput.tsx
@@ -35,8 +35,11 @@ export default function CardInput({
         onChange={handleChange}
         placeholder={placeholder}
         className={clsx(
-          "p-4 w-full resize-none rounded-md border border-[var(--color-gray3)] focus:border-[var(--primary)] outline-none bg-white",
-          small ? "text-sm" : "text-base",
+          "p-4 w-full resize-none",
+          "bg-white rounded-md border border-[var(--color-gray3)]",
+          "text-black font-normal",
+          "focus:border-[var(--primary)] outline-none",
+          small ? "text-[12px]" : "text-[14px]",
           className
         )}
         style={{
@@ -54,7 +57,13 @@ export default function CardInput({
           color="secondary"
           buttonSize="xs"
           onClick={onButtonClick}
-          className="absolute bottom-3 right-3 z-10 flex items-center justify-center w-[83px] h-[32px] border-gray-300 text-[#5534DA] cursor-pointer whitespace-nowrap rounded-sm"
+          className="absolute bottom-4 right-2.5 z-10 flex items-center justify-center
+          lg:w-[83px]
+          md:w-[77px] md:h-[32px]
+          w-[84px] h-[28px] rounded-sm
+          border-[var(--color-gray3)] hover:bg-gray-100
+          text-[var(--primary)] font-12m
+          cursor-pointer whitespace-nowrap"
         >
           입력
         </TextButton>

--- a/src/components/modalInput/ModalInput.tsx
+++ b/src/components/modalInput/ModalInput.tsx
@@ -150,7 +150,10 @@ export default function ModalInput({
 
     case "태그":
       inputElement = (
-        <div className="flex flex-wrap items-center gap-2 w-full max-w-[520px] min-h-[48px] border border-[var(--color-gray3)] rounded-md px-2 sm:px-4 overflow-x-auto scrollbar-hide focus-within:border-[var(--primary)]">
+        <div
+          className="flex flex-wrap items-center gap-2 py-2 pl-4
+        w-full max-w-[520px] min-h-[48px] border border-[var(--color-gray3)] rounded-md px-2 sm:px-4 overflow-x-auto scrollbar-hide focus-within:border-[var(--primary)]"
+        >
           {tags.map((tag, index) => (
             <ColorTagChip
               key={index}
@@ -158,7 +161,7 @@ export default function ModalInput({
               className={clsx(
                 tag.textColor,
                 tag.bgColor,
-                "px-3 py-1 rounded-lg font-14r"
+                "px-2 py-1 rounded-lg font-14r"
               )}
             >
               {tag.text}
@@ -172,7 +175,10 @@ export default function ModalInput({
             placeholder="입력 후 Enter"
             onChange={handleTagInputChange}
             onKeyDown={handleAddTag}
-            className="flex-grow min-w-[100px] h-full border-none font-normal text-[14px] sm:text-[16px] pl-2 outline-none"
+            className="flex-grow min-w-[100px] h-full
+            border-none outline-none
+            font-normal text-[14px] sm:text-[16px]
+            placeholder:sm:text-[14px] placeholder:text-[12px]"
           />
         </div>
       );

--- a/src/components/modalInput/StatusSelect.tsx
+++ b/src/components/modalInput/StatusSelect.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { useRouter } from "next/router";
 import axiosInstance from "@/api/axiosInstance";
 import { TEAM_ID } from "@/constants/team";
+import { ColumnNameTag } from "./chips/ColumnNameTag";
 
 export interface StatusOption {
   label: string;
@@ -77,12 +78,7 @@ export default function StatusSelect({
           onClick={() => setIsOpen(!isOpen)}
         >
           {selectedStatus ? (
-            <div className="flex items-center gap-2 bg-[#F3EDFF] rounded-full px-3 py-1">
-              <span className="w-2 h-2 rounded-full bg-[#5D2EFF]" />
-              <span className="text-sm text-[#5D2EFF]">
-                {selectedStatus.label}
-              </span>
-            </div>
+            <ColumnNameTag label={selectedStatus.label} />
           ) : (
             <span className="text-sm text-[var(--color-gray2)]">
               상태를 선택해 주세요

--- a/src/components/modalInput/chips/ColorTagChip.tsx
+++ b/src/components/modalInput/chips/ColorTagChip.tsx
@@ -40,7 +40,7 @@ export default function ColorTagChip({
     <button
       onClick={handleClick}
       className={clsx(
-        "px-3 py-2 rounded-lg font-14r whitespace-nowrap",
+        "px-3 py-1 rounded-[4px] font-12r whitespace-nowrap",
         className
       )}
     >

--- a/src/components/modalInput/chips/ColumnNameTag.tsx
+++ b/src/components/modalInput/chips/ColumnNameTag.tsx
@@ -1,0 +1,12 @@
+interface ColumnNameTagProps {
+  label: string;
+}
+
+export const ColumnNameTag = ({ label }: ColumnNameTagProps) => {
+  return (
+    <div className="gap-[6px] px-3 py-1 flex items-center bg-[#F3EDFF] rounded-full">
+      <span className="w-[6px] h-[6px] rounded-full bg-[var(--primary)]" />
+      <span className="font-12r text-[var(--primary)]">{label}</span>
+    </div>
+  );
+};

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -11,7 +11,7 @@ export interface UserType {
 
 export interface UpdateUser {
   nickname: string;
-  profileImageUrl: string;
+  profileImageUrl?: string;
 }
 
 export interface UserMeImage {


### PR DESCRIPTION
## 작업 내용
1. edit_Profile: 기존 프로필 이미지가 없을 때는 닉네임 변경이 되지 않아, 가능하도록 수정.
2. CardDetailModal: 전체적인 CSS 수정과 반응형 디자인 / 수정 과정에서 컴포넌트 분리.
카드 info 컴포넌트(Representative.tsx), 칼럼명 태그 컴포넌트(ColumnNameTag.tsx)
ColumnNameTag.tsx - 카드 편집 모달 내부 div 분리해서 재사용
3. CardDetailModal_CommentList: 작성된 댓글 없을 시 안내 메시지 표시
/ 스크롤-히든 제거 & 스크롤 표시되게 변경(추가 댓글이 있을 경우 사용자에게 알려주기 위함)

수정 전
![카드_CSS수정전](https://github.com/user-attachments/assets/20f987c2-c5be-48da-9d5b-3dd6cf45e75a)
![카드상세모달_수정전](https://github.com/user-attachments/assets/c353e853-90f5-44ec-86e8-25eff9419bb5)

수정 후
![카드상세모달_수정후3](https://github.com/user-attachments/assets/127c9168-8e50-4c64-9879-1c8e7c589ebd)
![카드상세모달_수정후1](https://github.com/user-attachments/assets/2198e662-ded0-4e22-ae79-913a9a39f526)
![카드상세모달_수정후2](https://github.com/user-attachments/assets/83c352b9-7e5c-443c-8927-749c06272fb3)