### PR TITLE
[Style, Refactor] CardDetail: 태그 영역 하단 이동 / dashboardindex: 칼럼 추가 버튼 반응형 출력 변경, 헤더&사이드메뉴 고정

### DIFF
--- a/src/components/modalDashboard/CardDetail.tsx
+++ b/src/components/modalDashboard/CardDetail.tsx
@@ -22,45 +22,15 @@ export default function CardDetail({ card, columnName }: CardDetailProps) {
 
   return (
     <div className="flex flex-col gap-5 w-full">
-      {/* 상태 + 태그 */}
-      <div className="flex flex-wrap items-center gap-5">
-        <ColumnNameTag label={columnName} />
-        <div className="w-[1px] h-[20px] bg-[var(--color-gray3)]" />
-        <div className="flex flex-wrap gap-[6px]">
-          {currentCard.tags.map((tag, idx) => {
-            const { textColor, bgColor } = getTagColor(idx);
-            return (
-              <ColorTagChip key={idx} className={`${textColor} ${bgColor}`}>
-                {tag}
-              </ColorTagChip>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* 설명 */}
-      <p className="text-black font-normal sm:text-[16px] text-[14px] overflow-auto pr-1 w-full lg:max-w-[445px] sm:max-w-[420px] max-w-[295px] min-h-0 sm:max-h-[100px] max-h-[80px] whitespace-pre-wrap word-break break-words">
+      {/* 내용 */}
+      <p
+        className="text-black font-normal sm:text-[16px] text-[14px] overflow-auto pr-1
+      w-full lg:max-w-[445px] sm:max-w-[420px] max-w-[295px]
+      min-h-0 sm:max-h-[140px] max-h-[80px]
+      whitespace-pre-wrap word-break break-words"
+      >
         {currentCard.description}
       </p>
-
-      {/* 담당자 */}
-      <div className="flex items-center gap-2 text-sm text-[var(--color-gray1)]">
-        <span className="font-medium">담당자:</span>
-        {currentCard.assignee.profileImageUrl ? (
-          <Image
-            src={currentCard.assignee.profileImageUrl}
-            alt="프로필 이미지"
-            width={24}
-            height={24}
-            className="w-6 h-6 rounded-full object-cover"
-          />
-        ) : (
-          <div className="w-6 h-6 flex items-center justify-center bg-[#A3C4A2] text-white font-medium rounded-full text-xs">
-            {currentCard.assignee.nickname[0]}
-          </div>
-        )}
-        <span>{currentCard.assignee.nickname}</span>
-      </div>
 
       {/* 이미지 */}
       {currentCard.imageUrl && (
@@ -80,6 +50,22 @@ export default function CardDetail({ card, columnName }: CardDetailProps) {
           />
         </div>
       )}
+
+      {/* 상태 + 태그 */}
+      <div className="flex flex-wrap items-center gap-5">
+        <ColumnNameTag label={columnName} />
+        <div className="w-[1px] h-[20px] bg-[var(--color-gray3)]" />
+        <div className="flex flex-wrap gap-[6px]">
+          {currentCard.tags.map((tag, idx) => {
+            const { textColor, bgColor } = getTagColor(idx);
+            return (
+              <ColorTagChip key={idx} className={`${textColor} ${bgColor}`}>
+                {tag}
+              </ColorTagChip>
+            );
+          })}
+        </div>
+      </div>
 
       {isImageModalOpen && currentCard.imageUrl && (
         <PopupImageModal

--- a/src/components/modalDashboard/CardDetailModal.tsx
+++ b/src/components/modalDashboard/CardDetailModal.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useRef, useState } from "react";
+import clsx from "clsx";
 import { MoreVertical, X } from "lucide-react";
 import CardDetail from "./CardDetail";
 import CommentList from "./CommentList";
-import CardInput from "@/components/modalInput/CardInput";
+import CommentInput from "@/components/modalInput/CardInput";
 import { Representative } from "@/components/modalDashboard/Representative";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createComment } from "@/api/comment";
@@ -106,18 +107,38 @@ export default function CardDetailPage({
 
   return (
     <>
-      <div className="fixed inset-0 bg-black/35 z-50 flex items-center justify-center px-4 sm:px-6">
-        <div className="relative flex flex-col overflow-y-auto max-w-[730px] max-h-[calc(100vh-4rem)] lg:w-[730px] sm:w-[678px] w-[327px] bg-white rounded-lg shadow-lg">
+      {/* 모달 고정 div */}
+      <div
+        className={clsx(
+          "fixed inset-0 z-50",
+          "flex items-center justify-center px-4 sm:px-6",
+          "bg-black/35"
+        )}
+      >
+        {/* 모달창 */}
+        <div
+          className={clsx(
+            "relative flex flex-col overflow-y-auto",
+            "lg:w-[730px] sm:w-[678px] w-[327px]",
+            "max-w-[730px] max-h-[calc(100vh-6rem)]",
+            "bg-white rounded-lg shadow-lg"
+          )}
+        >
           <div className="flex items-center justify-center px-6 pt-6 pb-2">
+            {/* 내부 아이템 컨테이너 */}
             <div className="flex flex-col lg:w-[674px] sm:w-[614px] w-[295px]">
+              {/* 헤더 컨테이너 */}
               <div className="flex justify-between sm:mb-4 mb-2">
+                {/* 제목 */}
                 <h2 className="text-black3 font-bold sm:text-[20px] text-[16px]">
                   {cardData.title}
                 </h2>
+                {/* 버튼 컨테이너 */}
                 <div
                   className="relative flex items-center sm:gap-[24px] gap-[16px]"
                   ref={popupRef}
                 >
+                  {/* 메뉴 버튼 */}
                   <button
                     onClick={() => setShowMenu((prev) => !prev)}
                     className="sm:w-[28px] sm:h-[28px] w-[20px] h-[20px] flex items-center justify-center hover:cursor-pointer"
@@ -126,6 +147,7 @@ export default function CardDetailPage({
                   >
                     <MoreVertical className="w-8 h-8 text-black3 cursor-pointer" />
                   </button>
+                  {/* 수정/삭제 드롭다운 메뉴 */}
                   {showMenu && (
                     <div className="absolute right-0 top-9.5 p-2 z-40 flex flex-col items-center justify-center sm:gap-[6px] gap-[11px] sm:w-28 w-20 sm:h-24 bg-white border border-[#D9D9D9] rounded-lg">
                       <button
@@ -153,6 +175,7 @@ export default function CardDetailPage({
                 </div>
               </div>
 
+              {/* 카드 내용 */}
               <div className="flex flex-col-reverse sm:flex-row gap-4">
                 <CardDetail card={cardData} columnName={columnName} />
                 <div>
@@ -160,11 +183,12 @@ export default function CardDetailPage({
                 </div>
               </div>
 
+              {/* 댓글 */}
               <div className="mt-4 w-full lg:max-w-[445px] md:max-w-[420px]">
                 <p className="mb-1 text-black3 font-medium sm:text-[16px] text-[14px]">
                   댓글
                 </p>
-                <CardInput
+                <CommentInput
                   hasButton
                   value={commentText}
                   onTextChange={setCommentText}

--- a/src/components/modalDashboard/CommentList.tsx
+++ b/src/components/modalDashboard/CommentList.tsx
@@ -44,7 +44,7 @@ export default function CommentList({
     >
       {allComments.length === 0 ? (
         <p
-          className="sm:pt-8 pt-4 text-center text-[var(--color-gray1)]
+          className="sm:pt-4 pt-2 text-center text-[var(--color-gray1)]
         font-normal sm:text-[14px] text-[12px]"
         >
           작성된 댓글이 없습니다.

--- a/src/components/modalDashboard/Representative.tsx
+++ b/src/components/modalDashboard/Representative.tsx
@@ -35,7 +35,7 @@ export const Representative = ({ card }: RepresentativeProps) => {
 
         {/* 마감일 컨테이너 */}
         <div>
-          <p className="font-12sb text-black3 sm:mb-1 mb-[4px]">마감일</p>
+          <p className="font-12sb text-black3 sm:mb-1 mb-[8px]">마감일</p>
           <p className="font-normal text-black3 sm:text-[14px] text-[12px]">
             {new Date(card.dueDate).toLocaleString("ko-KR", {
               year: "numeric",

--- a/src/components/modalInput/CardInput.tsx
+++ b/src/components/modalInput/CardInput.tsx
@@ -34,7 +34,7 @@ export default function CardInput({
         placeholder={placeholder}
         className={clsx(
           "sm:p-4 p-2 w-full resize-none",
-          "sm:h-[110px] h-[55px]",
+          "sm:h-[80px] h-[55px]",
           "bg-white rounded-md border border-[var(--color-gray3)]",
           "text-black3 font-normal sm:text-[14px] text-[12px]",
           "focus:border-[var(--primary)] outline-none",
@@ -62,7 +62,7 @@ export default function CardInput({
           text-[var(--primary)] font-12m
           cursor-pointer whitespace-nowrap"
           >
-            입력
+            등록
           </TextButton>
         </div>
       )}

--- a/src/pages/dashboard/[dashboardId]/index.tsx
+++ b/src/pages/dashboard/[dashboardId]/index.tsx
@@ -101,7 +101,7 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex h-screen min-h-screen">
       <SideMenu
         teamId={TEAM_ID}
         dashboardList={dashboardList}
@@ -135,7 +135,7 @@ export default function Dashboard() {
               />
             ))}
             {/* ColumnsButton: 모바일/태블릿에서는 하단 고정, 데스크탑에서는 원래 위치 */}
-            <div className={`py-10 px-2 hidden lg:block bg-white`}>
+            <div className={`lg:py-10 pb-5 lg:px-2 bg-white`}>
               <ColumnsButton onClick={openModal} />
             </div>
           </div>
@@ -173,15 +173,6 @@ export default function Dashboard() {
             />
           )}
         </main>
-        <div className="h-[100px] lg:hidden shrink-0" />
-        {/* fixed 버튼 (모바일, 태블릿용) */}
-        <div
-          className={`z-10 fixed bottom-0 left-[33px] md:left-[80px] w-full p-3
-            bg-white border-t border-gray-200 
-            flex justify-center lg:hidden`}
-        >
-          <ColumnsButton onClick={openModal} />
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 작업 내용
1. CardDetail: 기존 제목 - 태그 - 내용 - 이미지 순 출력에서, 이미지 하단에 태그 출력되게 디자인 변경
2. dashboardindex: 칼럼 추가 버튼 태블릿 이하 하단 고정 출력 -> 일반 출력 변경(칼럼은 카드와 달리 생성할 일이 적기 때문에, 고정 출력이 오히려 불편을 야기하는 것 같아 수정)
& 헤더, 사이드메뉴 고정(h-screen 추가)