### PR TITLE
[Refector] 컴포넌트 로직분리 

### DIFF
--- a/src/components/sideMenu/DashboardItem.tsx
+++ b/src/components/sideMenu/DashboardItem.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import Image from "next/image";
+import clsx from "clsx";
+
+interface Dashboard {
+  id: number;
+  title: string;
+  color: string;
+  createdByMe: boolean;
+}
+
+interface Props {
+  dashboard: Dashboard;
+  isCollapsed: boolean;
+  isActive: boolean;
+}
+
+export default function DashboardItem({
+  dashboard,
+  isCollapsed,
+  isActive,
+}: Props) {
+  return (
+    <li
+      className={clsx(
+        "flex w-full justify-center md:justify-start p-3 font-18m text-[var(--color-gray1)] transition-colors duration-200",
+        isActive &&
+          "bg-[var(--color-violet8)] text-[var(--color-black)] font-semibold rounded-xl"
+      )}
+    >
+      <Link
+        href={`/dashboard/${dashboard.id}`}
+        className="flex items-center gap-3"
+      >
+        <svg
+          width="8"
+          height="8"
+          viewBox="0 0 8 8"
+          fill={dashboard.color}
+          className="shrink-0"
+        >
+          <circle cx="4" cy="4" r="4" />
+        </svg>
+        {!isCollapsed && (
+          <div className="hidden md:flex min-w-0 items-center gap-1.5">
+            <span className="truncate md:text-base max-w-[100px] lg:max-w-[200px]">
+              {dashboard.title}
+            </span>
+            {dashboard.createdByMe && (
+              <Image
+                src="/svgs/crown.svg"
+                width={18}
+                height={14}
+                alt="크라운 아이콘"
+                unoptimized
+                priority
+              />
+            )}
+          </div>
+        )}
+      </Link>
+    </li>
+  );
+}

--- a/src/components/sideMenu/SideMenu.tsx
+++ b/src/components/sideMenu/SideMenu.tsx
@@ -5,6 +5,8 @@ import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
 import { PaginationButton } from "@/components/button/PaginationButton";
 import NewDashboard from "@/components/modal/NewDashboard";
+import DashboardItem from "@/components/sideMenu/DashboardItem";
+import usePagination from "@/hooks/usePagination";
 
 interface Dashboard {
   id: number;
@@ -26,7 +28,7 @@ function useMobile() {
   const [isMobile, setIsMobile] = useState(false);
   useEffect(() => {
     const handleResize = () => {
-      setIsMobile(window.innerWidth < 640); // sm 기준
+      setIsMobile(window.innerWidth < 640);
     };
     handleResize();
     window.addEventListener("resize", handleResize);
@@ -43,24 +45,113 @@ export default function SideMenu({
   const router = useRouter();
   const boardId = router.query.dashboardId?.toString();
   const isMobile = useMobile();
-
-  const [currentPage, setCurrentPage] = useState(1);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const itemsPerPage = 15;
-  const totalPages = Math.ceil(dashboardList.length / itemsPerPage);
-  const startIndex = (currentPage - 1) * itemsPerPage;
-  const endIndex = startIndex + itemsPerPage;
-  const paginatedDashboards = dashboardList.slice(startIndex, endIndex);
+  const {
+    currentPage,
+    totalPages,
+    paginatedItems: paginatedDashboards,
+    goToNextPage,
+    goToPrevPage,
+  } = usePagination(dashboardList, 15);
 
-  const handlePrev = () => {
-    if (currentPage > 1) setCurrentPage((prev) => prev - 1);
-  };
+  const toggleCollapse = () => setIsCollapsed((prev) => !prev);
 
-  const handleNext = () => {
-    if (currentPage < totalPages) setCurrentPage((prev) => prev + 1);
-  };
+  const renderLogo = () => (
+    <Link href="/mydashboard" className="mb-2">
+      {isCollapsed || isMobile ? (
+        <Image
+          src="/svgs/logo.svg"
+          alt="작은 로고"
+          width={24}
+          height={28}
+          priority
+          unoptimized
+        />
+      ) : (
+        <Image
+          src="/svgs/logo_taskify.svg"
+          alt="Taskify 로고"
+          width={109}
+          height={34}
+          priority
+          unoptimized
+        />
+      )}
+    </Link>
+  );
+
+  const renderCollapseButton = () => (
+    <div
+      className={clsx(
+        "hidden sm:flex",
+        isCollapsed ? "justify-center" : "justify-end",
+        "w-full"
+      )}
+    >
+      <button
+        onClick={toggleCollapse}
+        className="w-6 h-6 hover:bg-gray-200 rounded flex items-center justify-center border-none"
+      >
+        {isCollapsed ? (
+          <svg
+            className="w-2.5 h-2.5 text-gray-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+        ) : (
+          <svg
+            className="w-2.5 h-2.5 text-gray-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+
+  const renderAddButton = () => (
+    <div
+      className={clsx(
+        "mb-4",
+        isCollapsed
+          ? "flex justify-center"
+          : "flex items-center justify-between px-3 md:px-2"
+      )}
+    >
+      {!isCollapsed && (
+        <span className="hidden md:block font-12sb text-[var(--color-gray1)]">
+          Dash Boards
+        </span>
+      )}
+      <button onClick={() => setIsModalOpen(true)} className="cursor-pointer">
+        <Image
+          src="/svgs/icon-add-box.svg"
+          width={20}
+          height={20}
+          alt="추가 아이콘"
+          unoptimized
+        />
+      </button>
+    </div>
+  );
 
   return (
     <aside
@@ -72,122 +163,19 @@ export default function SideMenu({
           : "w-[67px] sm:w-[67px] md:w-[160px] lg:w-[300px] px-3"
       )}
     >
-      {/* 로고 영역 */}
       <div
         className={clsx(
           "flex flex-col mb-8",
           isCollapsed ? "items-center px-0" : "items-center md:items-start px-1"
         )}
       >
-        <Link href="/mydashboard" className="mb-2">
-          {isCollapsed || isMobile ? (
-            <Image
-              src="/svgs/logo.svg"
-              alt="작은 로고"
-              width={24}
-              height={28}
-              priority
-              unoptimized
-            />
-          ) : (
-            <Image
-              src="/svgs/logo_taskify.svg"
-              alt="Taskify 로고"
-              width={109}
-              height={34}
-              priority
-              unoptimized
-            />
-          )}
-        </Link>
-
-        {/* 접기/펼치기 버튼 (모바일에서는 숨김) */}
-        <div
-          className={clsx(
-            "hidden sm:flex",
-            isCollapsed ? "justify-center" : "justify-end",
-            "w-full"
-          )}
-        >
-          <button
-            onClick={() => setIsCollapsed(!isCollapsed)}
-            className="w-6 h-6 hover:bg-gray-200 rounded flex items-center justify-center ml-0 border-none"
-            title={isCollapsed ? "펼치기" : "접기"}
-          >
-            {isCollapsed ? (
-              <svg
-                className="w-2.5 h-2.5 text-gray-600"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 5l7 7-7 7"
-                />
-              </svg>
-            ) : (
-              <svg
-                className="w-2.5 h-2.5 text-gray-600"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 19l-7-7 7-7"
-                />
-              </svg>
-            )}
-          </button>
-        </div>
+        {renderLogo()}
+        {renderCollapseButton()}
       </div>
 
       <nav className="flex flex-1 flex-col min-h-0 justify-between h-full">
         <div>
-          {/* 대시보드 타이틀 + 추가 버튼 */}
-          {!isCollapsed && (
-            <div className="mb-4 flex items-center justify-between px-3 md:px-2">
-              <span className="hidden md:block font-12sb text-[var(--color-gray1)]">
-                Dash Boards
-              </span>
-              <button
-                className="ml-auto cursor-pointer"
-                onClick={() => setIsModalOpen(true)}
-              >
-                <Image
-                  src="/svgs/icon-add-box.svg"
-                  width={20}
-                  height={20}
-                  alt="추가 아이콘"
-                  unoptimized
-                />
-              </button>
-            </div>
-          )}
-
-          {isCollapsed && (
-            <div className="flex justify-center mb-4">
-              <button
-                onClick={() => setIsModalOpen(true)}
-                className="cursor-pointer"
-              >
-                <Image
-                  src="/svgs/icon-add-box.svg"
-                  width={20}
-                  height={20}
-                  alt="추가 아이콘"
-                  unoptimized
-                />
-              </button>
-            </div>
-          )}
-
-          {/* 대시보드 목록 */}
+          {renderAddButton()}
           <ul
             className={clsx(
               "flex-1",
@@ -197,68 +185,31 @@ export default function SideMenu({
             )}
           >
             {paginatedDashboards.map((dashboard) => (
-              <li
+              <DashboardItem
                 key={dashboard.id}
-                className={clsx(
-                  "flex w-full justify-center md:justify-start p-3 font-18m text-[var(--color-gray1)] transition-colors duration-200",
-                  dashboard.id.toString() === boardId &&
-                    "bg-[var(--color-violet8)] text-[var(--color-black)] font-semibold rounded-xl"
-                )}
-              >
-                <Link
-                  href={`/dashboard/${dashboard.id}`}
-                  className="flex items-center gap-3"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="8"
-                    height="8"
-                    viewBox="0 0 8 8"
-                    fill={dashboard.color}
-                    className="shrink-0"
-                  >
-                    <circle cx="4" cy="4" r="4" />
-                  </svg>
-                  {!isCollapsed && (
-                    <div className="hidden md:flex min-w-0 items-center gap-1.5">
-                      <span className="truncate md:text-base max-w-[100px] lg:max-w-[200px]">
-                        {dashboard.title}
-                      </span>
-                      {dashboard.createdByMe && (
-                        <Image
-                          src="/svgs/crown.svg"
-                          width={18}
-                          height={14}
-                          alt="크라운 아이콘"
-                          unoptimized
-                          priority
-                        />
-                      )}
-                    </div>
-                  )}
-                </Link>
-              </li>
+                dashboard={dashboard}
+                isCollapsed={isCollapsed}
+                isActive={dashboard.id.toString() === boardId}
+              />
             ))}
           </ul>
         </div>
 
-        {/* 페이지네이션 */}
-        {!isCollapsed && dashboardList.length > itemsPerPage && (
+        {!isCollapsed && dashboardList.length > 15 && (
           <div className="flex justify-start items-end mb-1 px-2">
             <PaginationButton
               direction="left"
               disabled={currentPage === 1}
-              onClick={handlePrev}
+              onClick={goToPrevPage}
             />
             <PaginationButton
               direction="right"
               disabled={currentPage === totalPages}
-              onClick={handleNext}
+              onClick={goToNextPage}
             />
           </div>
         )}
 
-        {/* 모달 */}
         {isModalOpen && (
           <NewDashboard
             teamId={teamId}

--- a/src/hooks/useCardDetail.ts
+++ b/src/hooks/useCardDetail.ts
@@ -1,0 +1,85 @@
+// src/hooks/useCardDetail.ts
+import { useState, useRef, useMemo } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { deleteCard } from "@/api/card";
+import { toast } from "react-toastify";
+import type { CardDetailType } from "@/types/cards";
+import { useClosePopup } from "@/hooks/useClosePopup";
+import { createComment } from "@/api/comment";
+
+export function useCardDetail(
+  card: CardDetailType,
+  dashboardId: number,
+  onChangeCard?: () => void,
+  onClose?: () => void
+) {
+  const [cardData, setCardData] = useState<CardDetailType>(card);
+  const [commentText, setCommentText] = useState("");
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [showMenu, setShowMenu] = useState(false);
+
+  const queryClient = useQueryClient();
+  const popupRef = useRef(null);
+
+  useClosePopup(popupRef, () => setShowMenu(false));
+
+  const { mutate: createCommentMutate } = useMutation({
+    mutationFn: createComment,
+    onSuccess: () => {
+      setCommentText("");
+      queryClient.invalidateQueries({ queryKey: ["comments", cardData.id] });
+    },
+  });
+
+  const { mutate: deleteCardMutate } = useMutation({
+    mutationFn: () => deleteCard(cardData.id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["cards"] });
+      onChangeCard?.();
+      setIsDeleteModalOpen(true);
+    },
+  });
+
+  const handleCommentSubmit = () => {
+    if (!commentText.trim()) return;
+    createCommentMutate({
+      content: commentText,
+      cardId: cardData.id,
+      columnId: cardData.columnId,
+      dashboardId,
+    });
+  };
+
+  const handleConfirmDelete = () => {
+    deleteCardMutate(undefined, {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["cards"] });
+        onChangeCard?.();
+        setIsDeleteModalOpen(false);
+        onClose?.();
+        toast.success("카드가 삭제되었습니다.");
+      },
+      onError: () => {
+        toast.error("카드 삭제에 실패했습니다.");
+        setIsDeleteModalOpen(false);
+      },
+    });
+  };
+
+  return {
+    cardData,
+    setCardData,
+    commentText,
+    setCommentText,
+    isEditModalOpen,
+    setIsEditModalOpen,
+    isDeleteModalOpen,
+    setIsDeleteModalOpen,
+    showMenu,
+    setShowMenu,
+    popupRef,
+    handleCommentSubmit,
+    handleConfirmDelete,
+  };
+}

--- a/src/hooks/useCardDetailState.ts
+++ b/src/hooks/useCardDetailState.ts
@@ -1,0 +1,39 @@
+import { useState, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getColumn } from "@/api/columns";
+import { CardDetailType } from "@/types/cards";
+import { getDashboardMembers } from "@/api/card";
+
+interface ColumnType {
+  id: number;
+  title: string;
+  status: string;
+}
+
+export function useCardDetailState(card: CardDetailType, dashboardId: number) {
+  const [cardData, setCardData] = useState<CardDetailType>(card);
+
+  const { data: columns = [] } = useQuery<ColumnType[]>({
+    queryKey: ["columns", dashboardId],
+    queryFn: () => getColumn({ dashboardId, columnId: card.columnId }),
+  });
+
+  const { data: members = [] } = useQuery({
+    queryKey: ["dashboardMembers", dashboardId],
+    queryFn: () => getDashboardMembers({ dashboardId }),
+  });
+
+  const columnName = useMemo(() => {
+    return (
+      columns.find((col) => col.id === cardData.columnId)?.title || "알 수 없음"
+    );
+  }, [columns, cardData.columnId]);
+
+  return {
+    cardData,
+    setCardData,
+    columnName,
+    columns,
+    members,
+  };
+}

--- a/src/hooks/useColumnStatus.ts
+++ b/src/hooks/useColumnStatus.ts
@@ -1,0 +1,27 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getColumn } from "@/api/columns";
+
+interface ColumnType {
+  id: number;
+  title: string;
+  status: string;
+}
+
+export function useColumnStatus(
+  dashboardId: number,
+  columnId: number,
+  status: string
+) {
+  const { data: columns = [] } = useQuery<ColumnType[]>({
+    queryKey: ["columns", dashboardId],
+    queryFn: () => getColumn({ dashboardId, columnId }),
+  });
+
+  const matchedColumn = useMemo(() => {
+    if (!columns.length) return undefined;
+    return columns.find((col) => col.title === status);
+  }, [columns, status]);
+
+  return matchedColumn?.id ?? columnId;
+}

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,28 @@
+import { useState, useMemo } from "react";
+
+export default function usePagination<T>(items: T[], itemsPerPage: number) {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalPages = Math.ceil(items.length / itemsPerPage);
+
+  const paginatedItems = useMemo(() => {
+    const start = (currentPage - 1) * itemsPerPage;
+    return items.slice(start, start + itemsPerPage);
+  }, [items, currentPage, itemsPerPage]);
+
+  const goToNextPage = () => {
+    if (currentPage < totalPages) setCurrentPage((prev) => prev + 1);
+  };
+
+  const goToPrevPage = () => {
+    if (currentPage > 1) setCurrentPage((prev) => prev - 1);
+  };
+
+  return {
+    currentPage,
+    totalPages,
+    paginatedItems,
+    goToNextPage,
+    goToPrevPage,
+  };
+}

--- a/src/hooks/useTaskForm.ts
+++ b/src/hooks/useTaskForm.ts
@@ -1,0 +1,115 @@
+import { useState, useMemo } from "react";
+import { toast } from "react-toastify";
+import { useQueryClient } from "@tanstack/react-query";
+import { createCard, editCard } from "@/api/card";
+import { TaskData } from "@/components/modalInput/TaskModal";
+
+interface Member {
+  id: number;
+  userId: number;
+  nickname: string;
+}
+
+interface UseTaskFormProps {
+  mode: "create" | "edit";
+  initialData: Partial<TaskData>;
+  members: Member[];
+  dashboardId: number;
+  columnId: number;
+  cardId?: number;
+  updatedColumnId: number;
+  onClose: () => void;
+  onSubmit: (data: TaskData) => void;
+}
+
+export function useTaskForm({
+  mode,
+  initialData,
+  members,
+  dashboardId,
+  columnId,
+  cardId,
+  updatedColumnId,
+  onClose,
+  onSubmit,
+}: UseTaskFormProps) {
+  const queryClient = useQueryClient();
+
+  const [formData, setFormData] = useState<TaskData>({
+    status: initialData.status || "",
+    assignee: initialData.assignee || "",
+    title: initialData.title || "",
+    description: initialData.description || "",
+    deadline: initialData.deadline ?? "",
+    tags: initialData.tags || [],
+    image: initialData.image || "",
+  });
+
+  const handleChange = (field: keyof TaskData, value: string | string[]) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const isFormValid = useMemo(() => {
+    return (
+      formData.assignee &&
+      formData.status &&
+      formData.title.trim() &&
+      formData.description.trim()
+    );
+  }, [formData]);
+
+  const handleSubmit = async () => {
+    try {
+      const selectedAssignee = members.find(
+        (m) => m.nickname === formData.assignee
+      );
+      const assigneeUserId = selectedAssignee?.userId;
+
+      if (!assigneeUserId) {
+        toast.error("담당자를 선택해 주세요.");
+        return;
+      }
+
+      if (mode === "create") {
+        await createCard({
+          assigneeUserId,
+          dashboardId,
+          columnId: updatedColumnId,
+          title: formData.title,
+          description: formData.description,
+          dueDate: formData.deadline.trim() ? formData.deadline : undefined,
+          tags: formData.tags,
+          imageUrl: formData.image || undefined,
+        });
+        toast.success("카드가 생성되었습니다.");
+      } else {
+        if (!cardId) {
+          toast.error("카드 ID가 없습니다.");
+          return;
+        }
+        await editCard(cardId, {
+          assigneeUserId,
+          columnId: updatedColumnId,
+          title: formData.title,
+          description: formData.description,
+          dueDate: formData.deadline.trim() ? formData.deadline : undefined,
+          tags: formData.tags,
+          imageUrl: formData.image || undefined,
+        });
+        queryClient.invalidateQueries({ queryKey: ["cards"] });
+        toast.success("카드가 수정되었습니다.");
+      }
+
+      onSubmit(formData);
+      onClose();
+    } catch (err) {
+      console.error("카드 처리 실패:", err);
+      toast.error(`카드 ${mode === "edit" ? "수정" : "생성"}에 실패했습니다.`);
+    }
+  };
+
+  return { formData, handleChange, isFormValid, handleSubmit };
+}

--- a/src/lib/dashboardUtils.ts
+++ b/src/lib/dashboardUtils.ts
@@ -1,0 +1,21 @@
+import { getDashboards } from "@/api/dashboards";
+import { dashboardOrdersTable } from "./dashboardOrderDB";
+import { DashboardType } from "@/types/task";
+
+export const fetchOrderedDashboards = async (
+  teamId: string
+): Promise<DashboardType[]> => {
+  const res = await getDashboards({});
+  const localOrder = await dashboardOrdersTable.get(teamId);
+
+  if (localOrder?.order) {
+    return res.dashboards
+      .slice()
+      .sort(
+        (a, b) =>
+          localOrder.order.indexOf(a.id) - localOrder.order.indexOf(b.id)
+      );
+  }
+
+  return res.dashboards;
+};

--- a/src/lib/useDashboardDragHandler.ts
+++ b/src/lib/useDashboardDragHandler.ts
@@ -1,0 +1,25 @@
+import { arrayMove } from "@dnd-kit/sortable";
+import { dashboardOrdersTable } from "./dashboardOrderDB";
+import { TEAM_ID } from "@/constants/team";
+import { DragEndEvent } from "@dnd-kit/core";
+import { DashboardType } from "@/types/task";
+
+export const useDashboardDragHandler = (
+  dashboards: DashboardType[],
+  setDashboards: (list: DashboardType[]) => void
+) => {
+  return async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = dashboards.findIndex((d) => d.id === active.id);
+    const newIndex = dashboards.findIndex((d) => d.id === over.id);
+    const newOrder = arrayMove(dashboards, oldIndex, newIndex);
+
+    setDashboards(newOrder);
+    await dashboardOrdersTable.put({
+      teamId: TEAM_ID,
+      order: newOrder.map((d) => d.id),
+    });
+  };
+};


### PR DESCRIPTION
## 작업 내용

- MyDashboardPage.tsx (나의 대시보드 페이지)
   D&D 핸들러 분리
   useDashboardDragHandler 커스텀 훅으로 handleDragEnd 로직 분리
   검색 필터링 useMemo 최적화, 대시보드 리스트 필터링 useMemo 적용
   선택된 대시보드 정보 selectedDashboard 객체로 통합 관리

- SideMenu.tsx (사이드 메뉴)
   로고 렌더링 함수 분리 → renderLogo()
   접기/펼치기 버튼 분리 → renderCollapseButton()
   추가 버튼 함수 분리 → renderAddButton()
   대시보드 아이템 분리 → renderDashboardItem()
   페이지네이션 로직 분리 → usePagination 커스텀 훅으로 리팩토링

- TaskModal.tsx (할 일 생성/수정 모달)
   useTaskForm 커스텀 훅으로 내부 상태 및 핸들러 분리
   Column 매칭 로직 분리 - useColumnStatus 훅으로 matchedColumn, updatedColumnId 관리

- CardDetailModal.tsx (카드 상세 모달)
   useCardDetailState로 cardData, columns, members 상태 분리
   댓글 및 모달 상태/로직 분리
   useCardDetail 훅으로 아래 상태 및 기능 분리: 댓글 작성, 수정 모달, 삭제 모달, 메뉴 팝업 열기, 삭제 처리


