### PR TITLE
[Fix, Refactor, Style] 전체: post 요청 중복 방지 / CommentList: 카드 담당자=댓글 작성자일 때만 수정/삭제되던 버그 fix

### DIFF
--- a/src/api/members.ts
+++ b/src/api/members.ts
@@ -32,11 +32,9 @@ export const getMembers = async ({
     });
 
     const members: Member[] = response.data.members || [];
-
-    console.log("✅ getMembers 응답 데이터:", members); // 디버깅용 로그
     return members;
   } catch (error) {
-    console.error("🚨 getMembers API 실패:", error);
+    console.error("getMembers API 실패:", error);
     return [];
   }
 };

--- a/src/components/modal/DeleteDashboardModal.tsx
+++ b/src/components/modal/DeleteDashboardModal.tsx
@@ -38,7 +38,9 @@ export default function DeleteDashboardModal({
       height="h-[160px] sm:h-[174px]"
     >
       <div className="flex flex-col sm:gap-10 gap-6 text-center">
-        <p className="text-xl mt-1.5">대시보드를 삭제하시겠습니까?</p>
+        <p className="text-black3 font-medium sm:text-[20px] text-[18px] mt-1.5">
+          대시보드를 삭제하시겠습니까?
+        </p>
         <div className="flex justify-between gap-3">
           <CustomBtn variant="outlineDisabled" onClick={onClose}>
             취소

--- a/src/components/modal/DeleteModal.tsx
+++ b/src/components/modal/DeleteModal.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Modal } from "@/components/modal/Modal";
 import { CustomBtn } from "../button/CustomButton";
-import { toast } from "react-toastify";
 
 interface DeleteModalProps {
   isOpen: boolean;

--- a/src/components/modal/NewDashboard.tsx
+++ b/src/components/modal/NewDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { usePostGuard } from "@/hooks/usePostGuard";
 import Input from "../input/Input";
 import Image from "next/image";
 import { createDashboard } from "@/api/dashboards";
@@ -23,8 +24,9 @@ interface NewDashboardProps {
 export default function NewDashboard({ onClose, onCreate }: NewDashboardProps) {
   const [title, setTitle] = useState("");
   const [selected, setSelected] = useState<number | null>(null);
-  const [loading, setLoading] = useState(false);
   const [titleLength, setTitleLength] = useState<number>(0);
+
+  const { guard: postGuard, isLoading } = usePostGuard();
 
   const maxTitleLength = 30;
   const colors = ["#7ac555", "#760DDE", "#FF9800", "#76A5EA", "#E876EA"];
@@ -44,16 +46,15 @@ export default function NewDashboard({ onClose, onCreate }: NewDashboardProps) {
     };
 
     try {
-      setLoading(true);
-      const response = await createDashboard(payload);
-      onCreate?.(response.data);
-      onClose?.();
-      toast.success("대시보드가 생성되었습니다.");
+      await postGuard(async () => {
+        const response = await createDashboard(payload);
+        onCreate?.(response.data);
+        onClose?.();
+        toast.success("대시보드가 생성되었습니다.");
+      });
     } catch (error) {
       console.error("대시보드 생성 실패:", error);
       toast.error("대시보드 생성에 실패했습니다.");
-    } finally {
-      setLoading(false);
     }
   };
 
@@ -116,12 +117,12 @@ export default function NewDashboard({ onClose, onCreate }: NewDashboardProps) {
           </button>
           <button
             onClick={handleSubmit}
-            disabled={!title || selected === null}
+            disabled={!title || selected === null || isLoading}
             className={`cursor-pointer sm:w-[256px] sm:h-[54px] w-[144px] h-[54px] rounded-[8px] 
             border border-[var(--color-gray3)] text-[var(--color-white)] 
             ${!title || selected === null ? "bg-gray-300 cursor-not-allowed" : "bg-[var(--primary)]"}`}
           >
-            {loading ? "생성 중..." : "생성"}
+            {isLoading ? "생성 중..." : "생성"}
           </button>
         </div>
       </div>

--- a/src/components/modalDashboard/CardDetailModal.tsx
+++ b/src/components/modalDashboard/CardDetailModal.tsx
@@ -32,8 +32,10 @@ export default function CardDetailPage({
   onChangeCard,
 }: CardDetailModalProps) {
   const { canEditCards } = useDashboardPermission(dashboardId, createdByMe);
-  const { cardData, setCardData, columnName, columns, members } =
-    useCardDetailState(card, dashboardId);
+  const { cardData, setCardData, columnName, members } = useCardDetailState(
+    card,
+    dashboardId
+  );
 
   const {
     commentText,
@@ -168,6 +170,7 @@ export default function CardDetailPage({
               setCardData(updatedCard);
               onChangeCard?.();
             } catch (error) {
+              console.error("카드 불러오기 실패:", error);
               toast.error("카드 정보를 불러오는 데 실패했습니다.");
             } finally {
               setIsEditModalOpen(false);

--- a/src/components/modalDashboard/CardDetailModal.tsx
+++ b/src/components/modalDashboard/CardDetailModal.tsx
@@ -7,7 +7,6 @@ import { Representative } from "@/components/modalDashboard/Representative";
 import TaskModal from "@/components/modalInput/TaskModal";
 import { DeleteModal } from "@/components/modal/DeleteModal";
 import { toast } from "react-toastify";
-import { TEAM_ID } from "@/constants/team";
 import { useDashboardPermission } from "@/hooks/useDashboardPermission";
 import { useCardDetailState } from "@/hooks/useCardDetailState";
 import { useCardDetail } from "@/hooks/useCardDetail";
@@ -16,7 +15,6 @@ import type { CardDetailType } from "@/types/cards";
 
 interface CardDetailModalProps {
   card: CardDetailType;
-  currentUserId: number;
   dashboardId: number;
   createdByMe: boolean;
   onClose: () => void;
@@ -25,7 +23,6 @@ interface CardDetailModalProps {
 
 export default function CardDetailPage({
   card,
-  currentUserId,
   dashboardId,
   createdByMe,
   onClose,
@@ -144,11 +141,7 @@ export default function CardDetailPage({
               </div>
 
               <div className="w-full lg:max-w-[445px] md:max-w-[420px] sm:max-h-[140px] max-h-[70px] my-2 overflow-y-auto">
-                <CommentList
-                  cardId={cardData.id}
-                  currentUserId={currentUserId}
-                  teamId={TEAM_ID}
-                />
+                <CommentList cardId={cardData.id} />
               </div>
             </div>
           </div>

--- a/src/components/modalDashboard/CommentList.tsx
+++ b/src/components/modalDashboard/CommentList.tsx
@@ -1,21 +1,19 @@
 import { useEffect } from "react";
 import { useInView } from "react-intersection-observer";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import useUserStore from "@/store/useUserStore";
 import { getComments } from "@/api/comment";
 import type { Comment as CommentType } from "@/types/comments";
 import UpdateComment from "./UpdateComment";
+import { TEAM_ID } from "@/constants/team";
 
 interface CommentListProps {
   cardId: number;
-  currentUserId: number;
-  teamId: string;
 }
 
-export default function CommentList({
-  cardId,
-  currentUserId,
-}: CommentListProps) {
+export default function CommentList({ cardId }: CommentListProps) {
   const { ref, inView } = useInView();
+  const { user } = useUserStore();
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery({
@@ -36,6 +34,8 @@ export default function CommentList({
   const allComments: CommentType[] =
     data?.pages.flatMap((page) => page.comments) ?? [];
 
+  if (!user) return null;
+
   return (
     <div
       className="min-h-[80px] sm:max-h-[240px] max-h-[215px] w-full
@@ -54,8 +54,8 @@ export default function CommentList({
           <div key={comment.id} className=" shrink-0 py-2 last:border-b-0">
             <UpdateComment
               comment={comment}
-              currentUserId={currentUserId}
-              teamId={""}
+              currentUserId={user.id}
+              teamId={TEAM_ID}
             />
           </div>
         ))

--- a/src/components/modalDashboard/Representative.tsx
+++ b/src/components/modalDashboard/Representative.tsx
@@ -8,13 +8,17 @@ interface RepresentativeProps {
 export const Representative = ({ card }: RepresentativeProps) => {
   return (
     <div
-      className="flex flex-col justify-center gap-4 sm:pl-4 pl-3
+      className="flex flex-col justify-center gap-4 sm:pl-4
       lg:w-[200px] sm:w-[180px] w-[290px]
       sm:h-[155px] h-[65px]
       rounded-lg bg-white border border-[#D9D9D9]"
     >
       {/* 내부 아이템 컨테이너 */}
-      <div className="flex sm:flex-col sm:gap-4 gap-17">
+      <div
+        className="flex items-center justify-center
+      sm:items-start sm:justify-between
+      sm:flex-col sm:gap-4 gap-18"
+      >
         {/* 담당자 컨테이너 */}
         <div>
           <p className="font-12sb text-black3 mb-[4px]">담당자</p>
@@ -36,18 +40,20 @@ export const Representative = ({ card }: RepresentativeProps) => {
 
         {/* 마감일 컨테이너 */}
         <div>
-          <p className="font-12sb text-black3 sm:mb-1 mb-[7px]">마감일</p>
-          <p className="font-normal text-black3 sm:text-[14px] text-[12px]">
-            {card.dueDate
-              ? new Date(card.dueDate).toLocaleString("ko-KR", {
-                  year: "numeric",
-                  month: "2-digit",
-                  day: "2-digit",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })
-              : "마감일 없음"}
-          </p>
+          <p className="font-12sb text-black3 mb-[4px]">마감일</p>
+          <div className="flex items-center w-full h-6">
+            <p className="font-normal text-black3 sm:text-[14px] text-[12px]">
+              {card.dueDate
+                ? new Date(card.dueDate).toLocaleString("ko-KR", {
+                    year: "numeric",
+                    month: "2-digit",
+                    day: "2-digit",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })
+                : "마감일 없음"}
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/modalDashboard/UpdateComment.tsx
+++ b/src/components/modalDashboard/UpdateComment.tsx
@@ -46,9 +46,6 @@ export default function UpdateComment({
     toast.success("댓글이 수정되었습니다.");
   };
 
-  console.log("currentUserId", currentUserId);
-  console.log("comment.author.id", comment.author.id);
-
   return (
     <div className="flex gap-3 items-start w-full">
       {/* 프로필 */}

--- a/src/components/modalDashboard/UpdateComment.tsx
+++ b/src/components/modalDashboard/UpdateComment.tsx
@@ -46,6 +46,9 @@ export default function UpdateComment({
     toast.success("댓글이 수정되었습니다.");
   };
 
+  console.log("currentUserId", currentUserId);
+  console.log("comment.author.id", comment.author.id);
+
   return (
     <div className="flex gap-3 items-start w-full">
       {/* 프로필 */}

--- a/src/components/modalInput/ModalInput.tsx
+++ b/src/components/modalInput/ModalInput.tsx
@@ -39,6 +39,13 @@ export default function ModalInput({
   const [titleLength, setTitleLength] = useState<number>(0);
   const maxTitleLength = 50;
 
+  // 기존 제목이 있다면 글자수 업데이트
+  useEffect(() => {
+    if (label === "제목" && defaultValue) {
+      setTitleLength(defaultValue.length);
+    }
+  }, [label, defaultValue]);
+
   useEffect(() => {
     if (label === "태그" && defaultValueArray.length > 0) {
       const initialTags = defaultValueArray.map((text, index) => ({

--- a/src/components/modalInput/TaskModal.tsx
+++ b/src/components/modalInput/TaskModal.tsx
@@ -61,7 +61,6 @@ export default function TaskModal({
     onClose,
     onSubmit,
   });
-  console.log("🔍 members in TaskModal", members);
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black/35 z-50">
       <div className="sm:w-[584px] w-[327px] h-[calc(var(--vh)_*_90)] rounded-lg bg-white p-4 sm:p-8 shadow-lg flex flex-col gap-4 sm:gap-8 overflow-y-auto">

--- a/src/hooks/usePostGuard.ts
+++ b/src/hooks/usePostGuard.ts
@@ -1,0 +1,24 @@
+import { useRef, useState } from "react";
+
+export function usePostGuard() {
+  const isPosting = useRef(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const guard = async <T>(callback: () => Promise<T>): Promise<T | null> => {
+    if (isPosting.current) return null;
+
+    isPosting.current = true;
+    setIsLoading(true);
+
+    try {
+      return await callback();
+    } catch (err) {
+      throw err;
+    } finally {
+      isPosting.current = false;
+      setIsLoading(false);
+    }
+  };
+
+  return { guard, isLoading };
+}

--- a/src/pages/dashboard/[dashboardId]/index.tsx
+++ b/src/pages/dashboard/[dashboardId]/index.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { useAuthGuard } from "@/hooks/useAuthGuard";
+import { usePostGuard } from "@/hooks/usePostGuard";
 import { getColumns, createColumn } from "@/api/columns";
 import { getCardsByColumn } from "@/api/card";
 import { getDashboards } from "@/api/dashboards";
@@ -23,6 +24,8 @@ import LoadingSpinner from "@/components/common/LoadingSpinner";
 export default function Dashboard() {
   const router = useRouter();
   const { user, isInitialized } = useAuthGuard();
+  const { guard: postGuard, isLoading } = usePostGuard();
+
   const { dashboardId } = router.query;
   const [columns, setColumns] = useState<ColumnType[]>([]);
   const [tasksByColumn, setTasksByColumn] = useState<TasksByColumn>({});
@@ -97,6 +100,7 @@ export default function Dashboard() {
       setTasksByColumn(columnTasks);
     } catch (err) {
       console.error("❌ 칼럼 또는 카드 로딩 에러:", err);
+      toast.error("데이터 로딩에 실패했습니다.");
     }
   };
 
@@ -189,14 +193,17 @@ export default function Dashboard() {
                 }
 
                 try {
-                  const newColumn = await createColumn({
-                    title: newColumnTitle,
-                    dashboardId: Number(dashboardId),
-                  });
+                  await postGuard(async () => {
+                    const newColumn = await createColumn({
+                      title: newColumnTitle,
+                      dashboardId: Number(dashboardId),
+                    });
 
-                  setColumns((prev) => [...prev, newColumn]);
-                  setNewColumnTitle("");
-                  setIsAddColumnModalOpen(false);
+                    setColumns((prev) => [...prev, newColumn]);
+                    setNewColumnTitle("");
+                    setIsAddColumnModalOpen(false);
+                    toast.success("칼럼이 생성되었습니다.");
+                  });
                 } catch (error) {
                   console.error("칼럼 생성 실패:", error);
                   toast.error("칼럼 생성에 실패했습니다.");

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
-import Image from "next/image";
 import { signUp } from "@/api/users";
-import Input from "@/components/input/Input";
+import { usePostGuard } from "@/hooks/usePostGuard";
+import Image from "next/image";
 import Link from "next/link";
+import Input from "@/components/input/Input";
 import { Modal } from "@/components/modal/Modal";
 import { CustomBtn } from "@/components/button/CustomButton";
 import { toast } from "react-toastify";
@@ -17,6 +18,7 @@ export default function SignUpPage() {
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
 
   const router = useRouter();
+  const { guard: postGuard, isLoading } = usePostGuard();
 
   const isFormValid =
     email.trim() !== "" &&
@@ -38,17 +40,19 @@ export default function SignUpPage() {
       toast.error("비밀번호가 일치하지 않습니다.");
       return;
     }
-
     if (!isFormValid) return;
+
     try {
-      await signUp({
-        payload: {
-          email,
-          nickname: nickName,
-          password,
-        },
+      await postGuard(async () => {
+        await signUp({
+          payload: {
+            email,
+            nickname: nickName,
+            password,
+          },
+        });
+        setIsSuccessModalOpen(true);
       });
-      setIsSuccessModalOpen(true);
     } catch (error) {
       console.error("회원가입 실패", error);
       toast.error("회원가입에 실패했습니다.");
@@ -141,14 +145,14 @@ export default function SignUpPage() {
 
         <button
           type="submit"
-          disabled={!isFormValid}
+          disabled={!isFormValid || isLoading}
           className={`w-full h-[50px] rounded-[8px] text-white font-18m transition mt-1 ${
             isFormValid
               ? "bg-[var(--primary)] cursor-pointer hover:opacity-90}"
               : "bg-[var(--color-gray2)] cursor-not-allowed"
           }`}
         >
-          가입하기
+          {isLoading ? "가입 중..." : "가입하기"}
         </button>
 
         <span className="font-16r text-center text-black3">


### PR DESCRIPTION
## 작업 내용
1. ModalInput: 카드 수정 시 제목 인풋창 변화 발생 전까지 현재 글자수 0으로 표시되던 문제 fix
2. usePostGuard 공통 훅 생성: 회원가입, 로그인, 대시보드 생성, 칼럼 생성, 카드 생성에 post 요청 중복 방지 적용
3. CommentList: 댓글 수정 권한 버그 fix
(전달받는 id 올바르게 수정)
4. CardDetailModal_Representative: 모바일에서 담당자 필드와 마감일 필드 수평 정렬 조정
(담당자 필드의 프로필아이콘 h-6에 맞춰 h-6 래퍼로 date 감쌈)

## 테스트 결과
- postGuard 적용 전
![post요청중복문제](https://github.com/user-attachments/assets/ad9c485e-be42-4814-b807-4a67d3e0611e)
- postGuard 적용 후
![대시보드생성_포스트가드](https://github.com/user-attachments/assets/7d653ceb-f94c-4418-8754-50f706b60d0d)

- 댓글 작성 권한 fix 전
![댓글수정권한테스트1-horz](https://github.com/user-attachments/assets/22c5eda1-944f-4fdb-b12f-20757fd1b332)

- 댓글 작성 권한 fix 후
![댓글수정권한테스트2-horz](https://github.com/user-attachments/assets/e81d02f1-e177-4b8c-b467-c482722d931c)